### PR TITLE
enabling context.getImageData()

### DIFF
--- a/src/pureimage.js
+++ b/src/pureimage.js
@@ -361,8 +361,11 @@ function Bitmap4BBPContext(bitmap) {
         };
     }
 
-
-
+    this.getImageData = function(x, y, widh, height) {
+      return {
+        data: new Uint8Array(this._bitmap._buffer)
+      };
+    };
 }
 
 exports.make = function(w,h,options) {


### PR DESCRIPTION
I'm aware this should respect the parameters, and behave a lot more like the original, but it's a useful start.