### PR TITLE
Fixed problem with wrong scanlines in polygon rendering.

### DIFF
--- a/src/pureimage.js
+++ b/src/pureimage.js
@@ -189,8 +189,10 @@ function Bitmap4BBPContext(bitmap) {
         var rgb = uint32.and(this._fillColor,0xFFFFFF00);
         var lines = pathToLines(this.path);
         var bounds = calcMinimumBounds(lines);
+        var startY = Math.min(bounds.y2-1, bitmap.height);
+        var endY = Math.max(bounds.y, 0);
 
-        for(var j=bounds.y2-1; j>=bounds.y; j--) {
+        for(var j=startY; j>=endY; j--) {
             var ints = calcSortedIntersections(lines,j);
             //fill between each pair of intersections
             for(var i=0; i<ints.length; i+=2) {

--- a/src/pureimage.js
+++ b/src/pureimage.js
@@ -586,7 +586,7 @@ function calcSortedIntersections(lines,y) {
             xlist.push(xval);
         }
     }
-    return xlist.sort(function(a,b) {  return a>b; });
+    return xlist.sort(function(a,b) {  return a-b; });
 }
 
 


### PR DESCRIPTION
Hello Josh,

This is a great library. I am using it for rendering maps. 
This pull-request fixes a problem occuring when rendering big polygons like shorelines. 
The polygons are then showing missing scanlines.

It would be very kind from you if you could integrate the fix into your code.

Best regards
Tim