### PR TITLE
Added synchronous font loading. Bumped opentype to latest version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "jpeg-js": "0.0.4",
-    "opentype.js": "^0.4.3",
+    "opentype.js": "^0.6.9",
     "pngjs": "^3.0.0",
     "richtext": "0.0.4"
   },

--- a/src/pureimage.js
+++ b/src/pureimage.js
@@ -474,6 +474,10 @@ exports.registerFont = function(binary, family, weight, style, variant) {
                 self.font = font;
                 if(cb)cb();
             });
+        },
+        loadSync: function() {
+            this.font = opentype.loadSync(binary);
+            this.loaded = true;
         }
     };
     return _fonts[family];

--- a/tests/text.js
+++ b/tests/text.js
@@ -3,7 +3,14 @@ var fs = require('fs');
 
 var fnt = PImage.registerFont('tests/fonts/SourceSansPro-Regular.ttf','Source Sans Pro');
 
-fnt.load(function() {
+// First test: render synchronously loading text
+fnt.loadSync();
+renderText('textSync');
+
+// Second test: render asynchronously (font is loaded at this point so it's going to be faster)
+fnt.load(function() { renderText('textAsync') });
+
+function renderText(fileName) {
     var img = PImage.make(200,200);
     var ctx = img.getContext('2d');
     ctx.fillStyle = "#ffffff";
@@ -36,7 +43,7 @@ fnt.load(function() {
     var diff = process.hrtime(before);
     console.log('without caching', diff);
 
-    PImage.encodePNG(img, fs.createWriteStream('build/text.png'), function(err) {
-        console.log("wrote out the png file to build/text.png");
+    PImage.encodePNG(img, fs.createWriteStream('build/' + fileName + '.png'), function(err) {
+        console.log("wrote out the png file to build/" + fileName + ".png");
     });
-});
+}


### PR DESCRIPTION
Hi! Thanks for such an awesome lib! I'm using your library to create font atlas in a react-native application. For my own use-case I needed to add synchronous loading of fonts. Since opentype at some point added the synchronous load function, I've updated your library to use the latest version of opentype. Thought you might be interested in merging this little addition back into your main project. 