### PR TITLE
Drawing on previously cleared rectangle does not work

### DIFF
--- a/src/pureimage.js
+++ b/src/pureimage.js
@@ -680,7 +680,7 @@ exports.compositePixel  = function(src,dst,omode) {
 
     var src_alpha = src_rgba[3]/255;
     var dst_alpha = dst_rgba[3]/255;
-    var final_a = dst_rgba[3];
+    var final_a = src_rgba[3];
 
     var final_rgba = [
         lerp(dst_rgba[0],src_rgba[0],src_alpha),

--- a/tests/simple_tests.js
+++ b/tests/simple_tests.js
@@ -171,6 +171,13 @@ function clearRectTest() {
      ctx.fillStyle = 'green';
      ctx.fillRect(0,0,100,100);
      ctx.clearRect(25,25,50,50);
+     ctx.strokeStyle = 'blue';
+     ctx.strokeWidth = 1;
+     ctx.beginPath();
+     ctx.moveTo(100,0);
+     ctx.lineTo(0,100);
+     ctx.stroke();
+     eq(ctx.getPixeli32(50,50), 0x0000FFff); // opaque blue
      eq(ctx.getPixeli32(1,1), 0x00FF00ff); // opaque green
      eq(ctx.getPixeli32(30,30), 0x00000000); //transparent black
      PImage.encodePNG(img, fs.createWriteStream('build/clearrect.png'), function(err) {


### PR DESCRIPTION
This pull request chooses the alpha of the src color instead of the alpha of the destination color in the compositePixel method.  When the dst alpha was used, if clearRect was performed and then a line was drawn over that cleared area, it would not show up.