### PR TITLE
Add Docblock Annotations

### DIFF
--- a/.esdoc.json
+++ b/.esdoc.json
@@ -1,0 +1,43 @@
+{
+    "source":"./src",
+    "destination":"./docs",
+    "includes":[
+        "\\.js$"
+    ],
+    "excludes":[
+        "\\.config\\.js$"
+    ],
+    "plugins":[
+        {
+            "name":"esdoc-standard-plugin",
+            "option":{
+                "lint":{
+                    "enable":true
+                },
+                "coverage":{
+                    "enable":true
+                },
+                "accessor":{
+                    "access":[
+                        "public",
+                        "protected",
+                        "private"
+                    ],
+                    "autoPrivate":true
+                },
+                "undocumentIdentifier":{
+                    "enable":true
+                },
+                "unexportedIdentifier":{
+                    "enable":false
+                },
+                "typeInference":{
+                    "enable":true
+                }
+            }
+        },
+        {
+            "name": "esdoc-node"
+        }
+    ]
+}

--- a/.esdoc.json
+++ b/.esdoc.json
@@ -5,7 +5,7 @@
         "\\.js$"
     ],
     "excludes":[
-        "\\.config\\.js$"
+        "\\uint32.js$"
     ],
     "plugins":[
         {

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 build
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 build
 .idea
+docs

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="Encoding">
-    <file url="PROJECT" charset="UTF-8" />
-  </component>
-</project>

--- a/.idea/jsLibraryMappings.xml
+++ b/.idea/jsLibraryMappings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="JavaScriptLibraryMappings">
-    <file url="file://$PROJECT_DIR$" libraries="{node-pureimage node_modules}" />
-    <includedPredefinedLibrary name="ECMAScript 6" />
-    <includedPredefinedLibrary name="Node.js Core" />
-  </component>
-</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="JavaScriptSettings">
-    <option name="languageLevel" value="ES6" />
-  </component>
-</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/node-pureimage.iml" filepath="$PROJECT_DIR$/.idea/node-pureimage.iml" />
-    </modules>
-  </component>
-</project>

--- a/.idea/node-pureimage.iml
+++ b/.idea/node-pureimage.iml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="WEB_MODULE" version="4">
-  <component name="NewModuleRootManager">
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/watcherTasks.xml
+++ b/.idea/watcherTasks.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectTasksOptions" suppressed-tasks="Babel" />
-</project>

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+    - "node"
+    - "7"
+    - "8"
+install: npm install --dev
+#after_success: npm run-script docs

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/robertmain/node-pureimage.svg?branch=master)](https://travis-ci.org/robertmain/node-pureimage)
+
 PureImage
 ==============
 

--- a/README.md
+++ b/README.md
@@ -80,14 +80,14 @@ Examples
 
 Make a new empty image, 100px by 50px. Automatically filled with 100% opaque black.
 
-```
+```js
 var PImage = require('pureimage');
 var img1 = PImage.make(100,50);
 ```
 
 Fill with a red rectangle with 50% opacity
 
-```
+```js
 var ctx = img1.getContext('2d');
 ctx.fillStyle = 'rgba(255,0,0, 0.5)';
 ctx.fillRect(0,0,100,100);
@@ -95,14 +95,14 @@ ctx.fillRect(0,0,100,100);
 
 Fill a green circle wiwth a radius of 40 pixels in the middle of a 100px square black image.
 
-```
-    var img = PImage.make(100,100);
-    var ctx = img.getContext('2d');
-    ctx.fillStyle = '#00ff00';
-    ctx.beginPath();
-    ctx.arc(50,50,40,0,Math.PI*2,true); // Outer circle
-    ctx.closePath();
-    ctx.fill();
+```js
+var img = PImage.make(100,100);
+var ctx = img.getContext('2d');
+ctx.fillStyle = '#00ff00';
+ctx.beginPath();
+ctx.arc(50,50,40,0,Math.PI*2,true); // Outer circle
+ctx.closePath();
+ctx.fill();
 ```
 
 ![image of arcto with some fringing bugs](firstimages/arcto.png)
@@ -110,7 +110,7 @@ Fill a green circle wiwth a radius of 40 pixels in the middle of a 100px square 
 Draw the string 'ABC' in white in the font 'Source Sans Pro', loaded from disk, at a size
 of 48 points. 
 
-```
+```js
 test('font test', (t) => {
     var fnt = PImage.registerFont('tests/fonts/SourceSansPro-Regular.ttf','Source Sans Pro');
     fnt.load(function() {
@@ -126,7 +126,7 @@ test('font test', (t) => {
 
 Write out to a PNG file
 
-```
+```js
 PImage.encodePNGToStream(img1, fs.createWriteStream('out.png')).then(()=> {
     console.log("wrote out the png file to out.png");
 }).catch((e)=>{
@@ -136,7 +136,7 @@ PImage.encodePNGToStream(img1, fs.createWriteStream('out.png')).then(()=> {
 
 Read a jpeg, resize it, then save it out
 
-```
+```js
 PImage.decodeJPEGFromStream(fs.createReadStream("tests/images/bird.jpg")).then((img)=>{
     console.log("size is",img.width,img.height);
     var img2 = PImage.make(50,50);
@@ -171,4 +171,3 @@ Thanks for patches from:
 * Lethexa [lethexa](https://github.com/lethexa)
 * The Louie [the-louie](https://github.com/the-louie)
 * Jan Marsch [kekscom](https://github.com/kekscom)
-* 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1756 @@
+{
+  "name": "pureimage",
+  "version": "0.1.3",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "abab": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
+      "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
+      "dev": true,
+      "optional": true
+    },
+    "acorn": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
+      "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc=",
+      "dev": true
+    },
+    "acorn-globals": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
+      "integrity": "sha1-VbtemGkVB7dFedBRNBMhfDgMVM8=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "acorn": "2.7.0"
+      }
+    },
+    "ajv": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
+      "integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "co": "4.6.0",
+        "fast-deep-equal": "1.0.0",
+        "json-schema-traverse": "0.3.1",
+        "json-stable-stringify": "1.0.1"
+      }
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+      "dev": true,
+      "optional": true
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true,
+      "optional": true
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true,
+      "optional": true
+    },
+    "aws4": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+      "dev": true,
+      "optional": true
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      }
+    },
+    "babel-generator": {
+      "version": "6.11.4",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.11.4.tgz",
+      "integrity": "sha1-FPaTOrsgxiZm0n47e59bncBxKpo=",
+      "dev": true,
+      "requires": {
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "detect-indent": "3.0.1",
+        "lodash": "4.17.4",
+        "source-map": "0.5.7"
+      }
+    },
+    "babel-messages": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
+      "requires": {
+        "core-js": "2.5.1",
+        "regenerator-runtime": "0.11.0"
+      }
+    },
+    "babel-traverse": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.12.0.tgz",
+      "integrity": "sha1-8i9U+g1u639jWFJGurbmN4WPXZQ=",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.14.1",
+        "debug": "2.6.9",
+        "globals": "8.18.0",
+        "invariant": "2.2.2",
+        "lodash": "4.17.4"
+      }
+    },
+    "babel-types": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.4",
+        "to-fast-properties": "1.0.3"
+      }
+    },
+    "babylon": {
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
+      "integrity": "sha1-lWJ1+rcnU62bNDXXr+WPi/CimBU=",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
+      "dev": true
+    },
+    "boom": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "hoek": "4.2.0"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true,
+      "optional": true
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      }
+    },
+    "cheerio": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
+      "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
+      "dev": true,
+      "requires": {
+        "css-select": "1.2.0",
+        "dom-serializer": "0.1.0",
+        "entities": "1.1.1",
+        "htmlparser2": "3.9.2",
+        "lodash.assignin": "4.2.0",
+        "lodash.bind": "4.2.1",
+        "lodash.defaults": "4.2.0",
+        "lodash.filter": "4.6.0",
+        "lodash.flatten": "4.4.0",
+        "lodash.foreach": "4.5.0",
+        "lodash.map": "4.6.0",
+        "lodash.merge": "4.6.0",
+        "lodash.pick": "4.4.0",
+        "lodash.reduce": "4.6.0",
+        "lodash.reject": "4.6.0",
+        "lodash.some": "4.6.0"
+      }
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true,
+      "optional": true
+    },
+    "color-logger": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/color-logger/-/color-logger-0.0.3.tgz",
+      "integrity": "sha1-2bIt0dlz4Waxi/MT+fSBu6TfIBg=",
+      "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "core-js": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+      "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "cryptiles": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "boom": "5.2.0"
+      },
+      "dependencies": {
+        "boom": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "hoek": "4.2.0"
+          }
+        }
+      }
+    },
+    "css-select": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+      "dev": true,
+      "requires": {
+        "boolbase": "1.0.0",
+        "css-what": "2.1.0",
+        "domutils": "1.5.1",
+        "nth-check": "1.0.1"
+      }
+    },
+    "css-what": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
+      "integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0=",
+      "dev": true
+    },
+    "cssom": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
+      "integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs=",
+      "dev": true
+    },
+    "cssstyle": {
+      "version": "0.2.37",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
+      "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "cssom": "0.3.2"
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true,
+      "optional": true
+    },
+    "define-properties": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "dev": true,
+      "requires": {
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
+      }
+    },
+    "defined": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+      "dev": true
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
+    "detect-indent": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
+      "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
+      "dev": true,
+      "requires": {
+        "get-stdin": "4.0.1",
+        "minimist": "1.2.0",
+        "repeating": "1.1.3"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "dom-serializer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.1.3",
+        "entities": "1.1.1"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+          "dev": true
+        }
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+      "dev": true
+    },
+    "domhandler": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
+      "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.3.0"
+      }
+    },
+    "domutils": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+      "dev": true,
+      "requires": {
+        "dom-serializer": "0.1.0",
+        "domelementtype": "1.3.0"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
+    },
+    "entities": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+      "dev": true
+    },
+    "es-abstract": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.9.0.tgz",
+      "integrity": "sha512-kk3IJoKo7A3pWJc0OV8yZ/VEX2oSUytfekrJiqoxBlKJMFAJVJVpGdHClCCTdv+Fn2zHfpDHHIelMFhZVfef3Q==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.1",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "dev": true,
+      "requires": {
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
+      }
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "escodegen": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
+      "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "esprima": "3.1.3",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.5.7"
+      }
+    },
+    "esdoc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/esdoc/-/esdoc-1.0.3.tgz",
+      "integrity": "sha512-TW2dYXpgfbhPnQG72ZVhOMSSa3ca0QmiXXzI8dq1OD9CC4PeJWvLdSLEgiaCeK72rrf8DuZswIhq+XOdtEMidg==",
+      "dev": true,
+      "requires": {
+        "babel-generator": "6.11.4",
+        "babel-traverse": "6.12.0",
+        "babylon": "6.14.1",
+        "cheerio": "0.22.0",
+        "color-logger": "0.0.3",
+        "escape-html": "1.0.3",
+        "fs-extra": "1.0.0",
+        "ice-cap": "0.0.4",
+        "marked": "0.3.6",
+        "minimist": "1.2.0",
+        "taffydb": "2.7.2"
+      }
+    },
+    "esdoc-accessor-plugin": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/esdoc-accessor-plugin/-/esdoc-accessor-plugin-1.0.0.tgz",
+      "integrity": "sha1-eRukhy5sQDUVznSbE0jW8Ck62es=",
+      "dev": true
+    },
+    "esdoc-brand-plugin": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/esdoc-brand-plugin/-/esdoc-brand-plugin-1.0.0.tgz",
+      "integrity": "sha1-niFtc15i/OxJ96M5u0Eh2mfMYDM=",
+      "dev": true,
+      "requires": {
+        "cheerio": "0.22.0"
+      }
+    },
+    "esdoc-coverage-plugin": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/esdoc-coverage-plugin/-/esdoc-coverage-plugin-1.1.0.tgz",
+      "integrity": "sha1-OGmGnNf4eJH5cmJXh2laKZrs5Fw=",
+      "dev": true
+    },
+    "esdoc-external-ecmascript-plugin": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/esdoc-external-ecmascript-plugin/-/esdoc-external-ecmascript-plugin-1.0.0.tgz",
+      "integrity": "sha1-ePVl1KDFGFrGMVJhTc4f4ahmiNs=",
+      "dev": true,
+      "requires": {
+        "fs-extra": "1.0.0"
+      }
+    },
+    "esdoc-integrate-manual-plugin": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/esdoc-integrate-manual-plugin/-/esdoc-integrate-manual-plugin-1.0.0.tgz",
+      "integrity": "sha1-GFSmqhwIEDXXyMUeO91PtlqkcRw=",
+      "dev": true
+    },
+    "esdoc-integrate-test-plugin": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/esdoc-integrate-test-plugin/-/esdoc-integrate-test-plugin-1.0.0.tgz",
+      "integrity": "sha1-4tDQAJD38MNeXS8sAzMnp55T5Ak=",
+      "dev": true
+    },
+    "esdoc-lint-plugin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esdoc-lint-plugin/-/esdoc-lint-plugin-1.0.1.tgz",
+      "integrity": "sha1-h77mQD5nbAh/Yb6SxFLWDyxqcOU=",
+      "dev": true
+    },
+    "esdoc-node": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/esdoc-node/-/esdoc-node-1.0.2.tgz",
+      "integrity": "sha1-PiHi4F+fNSIGAAHmOLZS8wqxqxI=",
+      "dev": true
+    },
+    "esdoc-publish-html-plugin": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/esdoc-publish-html-plugin/-/esdoc-publish-html-plugin-1.1.0.tgz",
+      "integrity": "sha1-CT+DN6yhaQIlcss4f/zD9HCwJRM=",
+      "dev": true,
+      "requires": {
+        "babel-generator": "6.11.4",
+        "cheerio": "0.22.0",
+        "escape-html": "1.0.3",
+        "fs-extra": "1.0.0",
+        "ice-cap": "0.0.4",
+        "marked": "0.3.6",
+        "taffydb": "2.7.2"
+      }
+    },
+    "esdoc-standard-plugin": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/esdoc-standard-plugin/-/esdoc-standard-plugin-1.0.0.tgz",
+      "integrity": "sha1-ZhIBysfvhokkkCRG/awVJyU8XU0=",
+      "dev": true,
+      "requires": {
+        "esdoc-accessor-plugin": "1.0.0",
+        "esdoc-brand-plugin": "1.0.0",
+        "esdoc-coverage-plugin": "1.1.0",
+        "esdoc-external-ecmascript-plugin": "1.0.0",
+        "esdoc-integrate-manual-plugin": "1.0.0",
+        "esdoc-integrate-test-plugin": "1.0.0",
+        "esdoc-lint-plugin": "1.0.1",
+        "esdoc-publish-html-plugin": "1.1.0",
+        "esdoc-type-inference-plugin": "1.0.1",
+        "esdoc-undocumented-identifier-plugin": "1.0.0",
+        "esdoc-unexported-identifier-plugin": "1.0.0"
+      }
+    },
+    "esdoc-type-inference-plugin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esdoc-type-inference-plugin/-/esdoc-type-inference-plugin-1.0.1.tgz",
+      "integrity": "sha1-qrynhkH5m9Hs5vMC8EW71jG+cvU=",
+      "dev": true
+    },
+    "esdoc-undocumented-identifier-plugin": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/esdoc-undocumented-identifier-plugin/-/esdoc-undocumented-identifier-plugin-1.0.0.tgz",
+      "integrity": "sha1-guBdNxwy0ShxFA8dXIHsmf2cwsg=",
+      "dev": true
+    },
+    "esdoc-unexported-identifier-plugin": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/esdoc-unexported-identifier-plugin/-/esdoc-unexported-identifier-plugin-1.0.0.tgz",
+      "integrity": "sha1-H5h0xqfCvr+a05fDzrdcnGnaurE=",
+      "dev": true
+    },
+    "esprima": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+      "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+      "dev": true,
+      "optional": true
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true,
+      "optional": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "dev": true,
+      "optional": true
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
+    "fast-deep-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+      "dev": true,
+      "optional": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true,
+      "optional": true
+    },
+    "for-each": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
+      "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
+      "dev": true,
+      "requires": {
+        "is-function": "1.0.1"
+      }
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true,
+      "optional": true
+    },
+    "form-data": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.17"
+      }
+    },
+    "fs-extra": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+      "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "jsonfile": "2.4.0",
+        "klaw": "1.3.1"
+      },
+      "dependencies": {
+        "klaw": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+          "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11"
+          }
+        }
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "get-stdin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+      "dev": true
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "globals": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
+      "integrity": "sha1-k9SmK9ysOM+vr8R9awNHaMsP/LQ=",
+      "dev": true
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true,
+      "optional": true
+    },
+    "har-validator": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "ajv": "5.2.3",
+        "har-schema": "2.0.0"
+      }
+    },
+    "has": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "dev": true,
+      "requires": {
+        "function-bind": "1.1.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "hawk": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "boom": "4.3.1",
+        "cryptiles": "3.1.2",
+        "hoek": "4.2.0",
+        "sntp": "2.0.2"
+      }
+    },
+    "hoek": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
+      "dev": true
+    },
+    "htmlparser2": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
+      "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.3.0",
+        "domhandler": "2.4.1",
+        "domutils": "1.5.1",
+        "entities": "1.1.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3"
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.13.1"
+      }
+    },
+    "ice-cap": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/ice-cap/-/ice-cap-0.0.4.tgz",
+      "integrity": "sha1-im0xq0ysjUtW3k+pRt8zUlYbbhg=",
+      "dev": true,
+      "requires": {
+        "cheerio": "0.20.0",
+        "color-logger": "0.0.3"
+      },
+      "dependencies": {
+        "cheerio": {
+          "version": "0.20.0",
+          "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.20.0.tgz",
+          "integrity": "sha1-XHEPK6uVZTJyhCugHG6mGzVF7DU=",
+          "dev": true,
+          "requires": {
+            "css-select": "1.2.0",
+            "dom-serializer": "0.1.0",
+            "entities": "1.1.1",
+            "htmlparser2": "3.8.3",
+            "jsdom": "7.2.2",
+            "lodash": "4.17.4"
+          }
+        },
+        "domhandler": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+          "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+          "dev": true,
+          "requires": {
+            "domelementtype": "1.3.0"
+          }
+        },
+        "htmlparser2": {
+          "version": "3.8.3",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+          "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+          "dev": true,
+          "requires": {
+            "domelementtype": "1.3.0",
+            "domhandler": "2.3.0",
+            "domutils": "1.5.1",
+            "entities": "1.0.0",
+            "readable-stream": "1.1.14"
+          },
+          "dependencies": {
+            "entities": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+              "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
+              "dev": true
+            }
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "invariant": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+      "dev": true,
+      "requires": {
+        "loose-envify": "1.3.1"
+      }
+    },
+    "is-callable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+      "dev": true
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
+    },
+    "is-finite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
+    },
+    "is-function": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
+      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU=",
+      "dev": true
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "1.0.1"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+      "dev": true
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true,
+      "optional": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true,
+      "optional": true
+    },
+    "jpeg-js": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.0.4.tgz",
+      "integrity": "sha1-Bqr0fv7HrwsZJKWc1pWm0rXthw4="
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true,
+      "optional": true
+    },
+    "jsdom": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-7.2.2.tgz",
+      "integrity": "sha1-QLQCdwwr2iNGkJa+6Rq2deOx/G4=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "abab": "1.0.4",
+        "acorn": "2.7.0",
+        "acorn-globals": "1.0.9",
+        "cssom": "0.3.2",
+        "cssstyle": "0.2.37",
+        "escodegen": "1.9.0",
+        "nwmatcher": "1.4.2",
+        "parse5": "1.5.1",
+        "request": "2.83.0",
+        "sax": "1.2.4",
+        "symbol-tree": "3.2.2",
+        "tough-cookie": "2.3.3",
+        "webidl-conversions": "2.0.1",
+        "whatwg-url-compat": "0.6.5",
+        "xml-name-validator": "2.0.1"
+      }
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true,
+      "optional": true
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "dev": true,
+      "optional": true
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "jsonify": "0.0.0"
+      }
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true,
+      "optional": true
+    },
+    "jsonfile": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true,
+      "optional": true
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
+    },
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+      "dev": true
+    },
+    "lodash.assignin": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
+      "integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI=",
+      "dev": true
+    },
+    "lodash.bind": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
+      "integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU=",
+      "dev": true
+    },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
+      "dev": true
+    },
+    "lodash.filter": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
+      "integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4=",
+      "dev": true
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
+      "dev": true
+    },
+    "lodash.foreach": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+      "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=",
+      "dev": true
+    },
+    "lodash.map": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
+      "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=",
+      "dev": true
+    },
+    "lodash.merge": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
+      "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU=",
+      "dev": true
+    },
+    "lodash.pick": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
+      "dev": true
+    },
+    "lodash.reduce": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
+      "integrity": "sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs=",
+      "dev": true
+    },
+    "lodash.reject": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz",
+      "integrity": "sha1-gNZJLcFHCGS79YNTO2UfQqn1JBU=",
+      "dev": true
+    },
+    "lodash.some": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
+      "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0=",
+      "dev": true
+    },
+    "loose-envify": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "dev": true,
+      "requires": {
+        "js-tokens": "3.0.2"
+      }
+    },
+    "marked": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
+      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=",
+      "dev": true
+    },
+    "mime-db": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.30.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "nth-check": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
+      "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
+      "dev": true,
+      "requires": {
+        "boolbase": "1.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
+    "nwmatcher": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.2.tgz",
+      "integrity": "sha512-QMkCGQFYp5p+zwU3INntLmz1HMfSx9dMVJMYKmE1yuSf/22Wjo6VPFa405mCLUuQn9lbQvH2DZN9lt10ZNvtAg==",
+      "dev": true,
+      "optional": true
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+      "dev": true,
+      "optional": true
+    },
+    "object-inspect": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.3.0.tgz",
+      "integrity": "sha512-OHHnLgLNXpM++GnJRyyhbr2bwl3pPVm4YvaraHrRvDt/N3r+s/gDVHciA7EJBTkijKXj61ssgSAikq1fb0IBRg==",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "opentype.js": {
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/opentype.js/-/opentype.js-0.4.11.tgz",
+      "integrity": "sha1-KBojkGOcwVkxyVXY1jwUp8d3K0E="
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      }
+    },
+    "parse5": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
+      "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ=",
+      "dev": true,
+      "optional": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "dev": true
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true,
+      "optional": true
+    },
+    "pngjs": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-0.4.0.tgz",
+      "integrity": "sha1-KUBxrcGytgv9SspNvkdZvM7m/Xc="
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "dev": true
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+      "dev": true,
+      "optional": true
+    },
+    "readable-stream": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
+    },
+    "regenerator-runtime": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
+      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+      "dev": true
+    },
+    "repeating": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+      "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+      "dev": true,
+      "requires": {
+        "is-finite": "1.0.2"
+      }
+    },
+    "request": {
+      "version": "2.83.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "aws-sign2": "0.7.0",
+        "aws4": "1.6.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.5",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.1",
+        "har-validator": "5.0.3",
+        "hawk": "6.0.2",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.17",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.1",
+        "safe-buffer": "5.1.1",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.3",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.1.0"
+      }
+    },
+    "resolve": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
+      "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
+    },
+    "resumer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+      "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+      "dev": true,
+      "requires": {
+        "through": "2.3.8"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "dev": true
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true,
+      "optional": true
+    },
+    "sntp": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
+      "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "hoek": "4.2.0"
+      }
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
+    },
+    "sshpk": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "string.prototype.trim": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
+      "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.9.0",
+        "function-bind": "1.1.1"
+      }
+    },
+    "stringstream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+      "dev": true,
+      "optional": true
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
+    },
+    "symbol-tree": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+      "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+      "dev": true,
+      "optional": true
+    },
+    "taffydb": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.7.2.tgz",
+      "integrity": "sha1-e/gQalwaSCUbPjvAoOFzJIn9Dcg=",
+      "dev": true
+    },
+    "tape": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-4.8.0.tgz",
+      "integrity": "sha512-TWILfEnvO7I8mFe35d98F6T5fbLaEtbFTG/lxWvid8qDfFTxt19EBijWmB4j3+Hoh5TfHE2faWs73ua+EphuBA==",
+      "dev": true,
+      "requires": {
+        "deep-equal": "1.0.1",
+        "defined": "1.0.0",
+        "for-each": "0.3.2",
+        "function-bind": "1.1.1",
+        "glob": "7.1.2",
+        "has": "1.0.1",
+        "inherits": "2.0.3",
+        "minimist": "1.2.0",
+        "object-inspect": "1.3.0",
+        "resolve": "1.4.0",
+        "resumer": "0.0.0",
+        "string.prototype.trim": "1.1.2",
+        "through": "2.3.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "to-fast-properties": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+      "dev": true
+    },
+    "tough-cookie": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+      "dev": true,
+      "requires": {
+        "punycode": "1.4.1"
+      }
+    },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true,
+      "optional": true
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true,
+      "optional": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "uuid": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+      "dev": true,
+      "optional": true
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
+      }
+    },
+    "webidl-conversions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-2.0.1.tgz",
+      "integrity": "sha1-O/glj30xjHRDw28uFpQCoaZwNQY=",
+      "dev": true,
+      "optional": true
+    },
+    "whatwg-url-compat": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/whatwg-url-compat/-/whatwg-url-compat-0.6.5.tgz",
+      "integrity": "sha1-AImBEa9om7CXVBzVpFymyHmERb8=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tr46": "0.0.3"
+      }
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true,
+      "optional": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "xml-name-validator": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
+      "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=",
+      "dev": true,
+      "optional": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,9 +18,14 @@
     "pngjs": "^0.4.0"
   },
   "devDependencies": {
-    "tape":"^4.6.3"
+    "esdoc": "^1.0.3",
+    "esdoc-node": "^1.0.2",
+    "esdoc-standard-plugin": "^1.0.0",
+    "tape": "^4.6.3"
   },
   "scripts": {
-    "test": "node tests/runtests.js"
-  }
+    "test": "node tests/runtests.js",
+    "docs": "./node_modules/.bin/esdoc"
+  },
+  "license": "MIT"
 }

--- a/src/bitmap.js
+++ b/src/bitmap.js
@@ -1,9 +1,21 @@
-"use strict";
-var uint32 = require('./uint32');
-var Context = require('./context');
+const uint32 = require('./uint32');
+const Context = require('./context');
 
+/**
+ * Bitmap
+ * 
+ * @class Bitmap
+ */
 class Bitmap {
-    constructor(w,h,options) {
+
+    /**
+     * Creates an instance of Bitmap.
+     * @param {number} w Width
+     * @param {number} h Height
+     * @param {any} options Currently unused
+     * @memberof Bitmap
+     */
+    constructor(w,h, options) {
         this.width = Math.floor(w);
         this.height = Math.floor(h);
         this.data = Buffer.alloc(w*h*4);
@@ -15,12 +27,32 @@ class Bitmap {
         }
 
     }
+
+    /**
+     * Calculate Index
+     * 
+     * Calculate the 
+     * 
+     * @param {number} x X position
+     * @param {number} y Y position
+     * @returns {number}
+     * @memberof Bitmap
+     */
     calculateIndex (x,y) {
         x = Math.floor(x);
         y = Math.floor(y);
         if (x<0 || y<0 || x >= this.width || y >= this.height) return 0;
         return (this.width*y+x)*4;
     }
+
+    /**
+     * Set Pixel RGBA
+     * 
+     * @param {number} x X position
+     * @param {number} y Y position
+     * @param {number} rgba The source to be extracted
+     * @memberof Bitmap
+     */
     setPixelRGBA(x,y,rgba) {
         let i = this.calculateIndex(x, y);
         const bytes = uint32.getBytesBigEndian(rgba);
@@ -29,6 +61,18 @@ class Bitmap {
         this.data[i+2] = bytes[2];
         this.data[i+3] = bytes[3];
     }
+
+    /**
+     * Set Pixel RGBA_i
+     * 
+     * @param {number} x X position
+     * @param {number} y Y position
+     * @param {number} r Red level
+     * @param {number} g Green level
+     * @param {number} b Blue level
+     * @param {number} a Alpha level
+     * @memberof Bitmap
+     */
     setPixelRGBA_i(x,y,r,g,b,a) {
         let i = this.calculateIndex(x, y);
         this.data[i+0] = r;
@@ -36,6 +80,15 @@ class Bitmap {
         this.data[i+2] = b;
         this.data[i+3] = a;
     }
+
+    /**
+     * Get Pixel RGBA
+     * 
+     * @param {number} x X potiion
+     * @param {number} y Y position
+     * @returns {number}
+     * @memberof Bitmap
+     */
     getPixelRGBA(x,y) {
         let i = this.calculateIndex(x, y);
         return uint32.fromBytesBigEndian(
@@ -44,14 +97,29 @@ class Bitmap {
             this.data[i+2],
             this.data[i+3]);
     }
+
+    /**
+     * Get Pixel RGBA Seperate
+     * 
+     * @param {number} x X position
+     * @param {number} y Y position
+     * @returns 
+     * @memberof Bitmap
+     */
     getPixelRGBA_separate(x,y) {
         var i = this.calculateIndex(x,y);
         return this.data.slice(i,i+4);
     }
-    getContext(type) {
+
+    /**
+     * Get Context
+     * Get a new {Context} object for the current bitmap object
+     * 
+     * @returns {Context}
+     * @memberof Bitmap
+     */
+    getContext() {
         return new Context(this);
     }
 }
 module.exports = Bitmap;
-
-

--- a/src/bitmap.js
+++ b/src/bitmap.js
@@ -12,9 +12,9 @@ class Bitmap {
 
     /**
      * Creates an instance of Bitmap.
-     * @param {number} w Width
-     * @param {number} h Height
-     * @param {any} options Currently unused
+     * @param {number} w      Width
+     * @param {number} h      Height
+     * @param {any}   options Currently unused
      * @memberof Bitmap
      */
     constructor(w,h, options) {
@@ -63,8 +63,8 @@ class Bitmap {
     /**
      * Set Pixel RGBA
      * 
-     * @param {number} x X position
-     * @param {number} y Y position
+     * @param {number} x    X position
+     * @param {number} y    Y position
      * @param {number} rgba The source to be extracted
      * 
      * @returns {void}

--- a/src/bitmap.js
+++ b/src/bitmap.js
@@ -16,9 +16,22 @@ class Bitmap {
      * @memberof Bitmap
      */
     constructor(w,h, options) {
+        
+        /**
+         * @type {number}
+         */
         this.width = Math.floor(w);
+        
+        /**
+         * @type {number}
+         */
         this.height = Math.floor(h);
+        
+        /**
+         * @type {ArrayBuffer}
+         */
         this.data = Buffer.alloc(w*h*4);
+
         var fillval = 0x000000FF;
         for(var j=0; j<h; j++) {
             for (var i = 0; i < w; i++) {
@@ -33,7 +46,9 @@ class Bitmap {
      * 
      * @param {number} x X position
      * @param {number} y Y position
+     * 
      * @returns {number}
+     * 
      * @memberof Bitmap
      */
     calculateIndex (x,y) {
@@ -49,6 +64,9 @@ class Bitmap {
      * @param {number} x X position
      * @param {number} y Y position
      * @param {number} rgba The source to be extracted
+     * 
+     * @returns {void}
+     * 
      * @memberof Bitmap
      */
     setPixelRGBA(x,y,rgba) {
@@ -69,6 +87,9 @@ class Bitmap {
      * @param {number} g Green level
      * @param {number} b Blue level
      * @param {number} a Alpha level
+     * 
+     * @returns {void}
+     * 
      * @memberof Bitmap
      */
     setPixelRGBA_i(x,y,r,g,b,a) {
@@ -84,7 +105,9 @@ class Bitmap {
      * 
      * @param {number} x X potiion
      * @param {number} y Y position
+     * 
      * @returns {number}
+     * 
      * @memberof Bitmap
      */
     getPixelRGBA(x,y) {
@@ -101,7 +124,9 @@ class Bitmap {
      * 
      * @param {number} x X position
      * @param {number} y Y position
-     * @returns 
+     * 
+     * @returns {void}
+     * 
      * @memberof Bitmap
      */
     getPixelRGBA_separate(x,y) {
@@ -114,6 +139,7 @@ class Bitmap {
      * Get a new {Context} object for the current bitmap object
      * 
      * @returns {Context}
+     * 
      * @memberof Bitmap
      */
     getContext() {

--- a/src/bitmap.js
+++ b/src/bitmap.js
@@ -31,8 +31,6 @@ class Bitmap {
     /**
      * Calculate Index
      * 
-     * Calculate the 
-     * 
      * @param {number} x X position
      * @param {number} y Y position
      * @returns {number}

--- a/src/bitmap.js
+++ b/src/bitmap.js
@@ -1,4 +1,6 @@
+/**@ignore */
 const uint32 = require('./uint32');
+/**@ignore */
 const Context = require('./context');
 
 /**
@@ -136,8 +138,8 @@ class Bitmap {
 
     /**
      * Get Context
-     * Get a new {Context} object for the current bitmap object
-     * 
+     * Get a new {@link Context} object for the current bitmap object
+     * `
      * @returns {Context}
      * 
      * @memberof Bitmap

--- a/src/bitmap.js
+++ b/src/bitmap.js
@@ -5,7 +5,7 @@ const Context = require('./context');
 
 /**
  * Bitmap
- * 
+ *
  * @class Bitmap
  */
 class Bitmap {
@@ -18,17 +18,17 @@ class Bitmap {
      * @memberof Bitmap
      */
     constructor(w,h, options) {
-        
+
         /**
          * @type {number}
          */
         this.width = Math.floor(w);
-        
+
         /**
          * @type {number}
          */
         this.height = Math.floor(h);
-        
+
         /**
          * @type {ArrayBuffer}
          */
@@ -45,12 +45,12 @@ class Bitmap {
 
     /**
      * Calculate Index
-     * 
+     *
      * @param {number} x X position
      * @param {number} y Y position
-     * 
+     *
      * @returns {number}
-     * 
+     *
      * @memberof Bitmap
      */
     calculateIndex (x,y) {
@@ -62,13 +62,13 @@ class Bitmap {
 
     /**
      * Set Pixel RGBA
-     * 
+     *
      * @param {number} x    X position
      * @param {number} y    Y position
      * @param {number} rgba The source to be extracted
-     * 
+     *
      * @returns {void}
-     * 
+     *
      * @memberof Bitmap
      */
     setPixelRGBA(x,y,rgba) {
@@ -82,16 +82,16 @@ class Bitmap {
 
     /**
      * Set Pixel RGBA_i
-     * 
+     *
      * @param {number} x X position
      * @param {number} y Y position
      * @param {number} r Red level
      * @param {number} g Green level
      * @param {number} b Blue level
      * @param {number} a Alpha level
-     * 
+     *
      * @returns {void}
-     * 
+     *
      * @memberof Bitmap
      */
     setPixelRGBA_i(x,y,r,g,b,a) {
@@ -104,12 +104,12 @@ class Bitmap {
 
     /**
      * Get Pixel RGBA
-     * 
+     *
      * @param {number} x X potiion
      * @param {number} y Y position
-     * 
+     *
      * @returns {number}
-     * 
+     *
      * @memberof Bitmap
      */
     getPixelRGBA(x,y) {
@@ -123,12 +123,12 @@ class Bitmap {
 
     /**
      * Get Pixel RGBA Seperate
-     * 
+     *
      * @param {number} x X position
      * @param {number} y Y position
-     * 
+     *
      * @returns {void}
-     * 
+     *
      * @memberof Bitmap
      */
     getPixelRGBA_separate(x,y) {
@@ -139,9 +139,9 @@ class Bitmap {
     /**
      * Get Context
      * Get a new {@link Context} object for the current bitmap object
-     * `
+     *
      * @returns {Context}
-     * 
+     *
      * @memberof Bitmap
      */
     getContext() {

--- a/src/context.js
+++ b/src/context.js
@@ -1,30 +1,65 @@
 "use strict";
+/**@ignore */
 var uint32 = require('./uint32');
+/**@ignore */
 var NAMED_COLORS = require('./named_colors');
+/**@ignore */
 var trans = require('./transform');
+/**@ignore */
 var TEXT = require('./text');
 
+/**
+ * Context
+ * 
+ * @class Context
+ */
 class Context {
+
+    /**
+     * Creates a new pure image Context
+     * 
+     * @param {Bitmap} bitmap An instance of the {@link Bitmap} class
+     * @memberof Context
+     */
     constructor(bitmap) {
+        /**
+         * @type {Bitmap}
+         */
         this.bitmap = bitmap;
+
+        /**
+         * @type {number}
+         */
         this._fillColor = 0x000000FF;
         Object.defineProperty(this, 'fillStyle', {
             get: function() { return this._fillStyle_text; },
             set: function(val) {
                 this._fillColor = Context.colorStringToUint32(val);
+                /**
+                 * @type {string}
+                 */
                 this._fillStyle_text = val;
             }
         });
 
+        /**
+         * @type {number}
+         */
         this._strokeColor = 0x000000FF;
         Object.defineProperty(this, 'strokeStyle', {
             get: function() { return this._strokeStyle_text; },
             set: function(val) {
                 this._strokeColor = Context.colorStringToUint32(val);
+                /**
+                 * @type {string}
+                 */
                 this._strokeStyle_text = val;
             }
         });
 
+        /**
+         * @type {number}
+         */
         this._lineWidth = 1;
         Object.defineProperty(this, 'lineWidth', {
             get: function() { return this._lineWidth; },
@@ -33,6 +68,9 @@ class Context {
             }
         });
 
+        /**
+         * @type {number}
+         */
         this._globalAlpha = 1;
         Object.defineProperty(this, 'globalAlpha', {
             get: function() { return this._globalAlpha; },
@@ -41,7 +79,14 @@ class Context {
             }
         });
 
+        /**
+         * @type {Transform}
+         */
         this.transform = new trans.Transform();
+        
+        /**
+         * @type {object}
+         */
         this._font = {
             family:'invalid',
             size:12
@@ -60,29 +105,105 @@ class Context {
             }
         });
 
+        /**
+         * @type {boolean}
+         */
         this.imageSmoothingEnabled = true;
+        
+        /**
+         * @type {?any}
+         */
         this._clip = null;
     }
 
-    // transforms and state saving
+    /**
+     * Save
+     * 
+     * Save the current state of the transform
+     * 
+     * @see {@link Transform}
+     * 
+     * @returns {void}
+     * 
+     * @memberof Context
+     */
     save() {
         this.transform.save();
     }
+
+    /**
+     * Translate
+     * 
+     * Translate the context according to the X and Y co-ordinates passed in
+     * 
+     * @param {number} x X position
+     * @param {number} y Y position
+     * 
+     * @returns {void}
+     * 
+     * @memberof Context
+     */
     translate(x,y) {
         this.transform.translate(x,y);
     }
+
+    /**
+     * Rotate
+     * 
+     * Rorate the 
+     * 
+     * @param {number} angle The degrees of rotation (in radians)
+     * 
+     * @returns {void}
+     * 
+     * @memberof Context
+     */
     rotate(angle) {
         this.transform.rotate(angle);
     }
+
+    /**
+     * Scale
+     * 
+     * Scale the current context by the amount given
+     * 
+     * @param {number} sx Scale X amount
+     * @param {number} sy Scale Y amount
+     * 
+     * @returns {void}
+     * 
+     * @memberof Context
+     */
     scale(sx,sy) {
         this.transform.scale(sx,sy);
     }
+
+    /**
+     * Restore
+     * 
+     * @returns {void}
+     * 
+     * @memberof Context
+     */
     restore() {
         this.transform.restore();
     }
 
 
-    //simple rect
+    /**
+     * Fill Rect
+     * 
+     * Draw a simple rectangle
+     * 
+     * @param {number} x X position
+     * @param {number} y Y position
+     * @param {number} w Width
+     * @param {number} h Height
+     * 
+     * @returns {void}
+     * 
+     * @memberof Context
+     */
     fillRect(x,y,w,h) {
         for(var i=x; i<x+w; i++) {
             for(var j=y; j<y+h; j++) {
@@ -90,6 +211,19 @@ class Context {
             }
         }
     }
+
+    /**
+     * Clear Rect
+     * 
+     * @param {number} x X position
+     * @param {number} y Y position
+     * @param {number} w Width
+     * @param {number} h Height
+     * 
+     * @returns {void}
+     * 
+     * @memberof Context
+     */
     clearRect(x,y,w,h) {
         for(var i=x; i<x+w; i++) {
             for(var j=y; j<y+h; j++) {
@@ -97,6 +231,19 @@ class Context {
             }
         }
     }
+
+    /**
+     * Stroke Rect
+     * 
+     * @param {number} x X position
+     * @param {number} y Y position
+     * @param {number} w Width
+     * @param {number} h Height
+     * 
+     * @returns {void}
+     * 
+     * @memberof Context
+     */
     strokeRect(x,y,w,h) {
         for(var i=x; i<x+w; i++) {
             this.bitmap.setPixelRGBA(i, y, this._strokeColor);
@@ -108,8 +255,18 @@ class Context {
         }
     }
 
-
-    //set single pixel
+    /**
+     * Fill Pixel
+     * 
+     * Set a single pixel
+     * 
+     * @param {number} i 
+     * @param {number} j 
+     * 
+     * @returns {void}
+     * 
+     * @memberof Context
+     */
     fillPixel(i,j) {
         if(!this.pixelInsideClip(i,j)) return;
         var new_pixel = this.calculateRGBA(i,j);
@@ -117,6 +274,17 @@ class Context {
         var final_pixel = this.composite(i,j,old_pixel,new_pixel);
         this.bitmap.setPixelRGBA(i,j,final_pixel);
     }
+
+    /**
+     * Stroke Pixel
+     * 
+     * @param {number} i
+     * @param {number} j
+     * 
+     * @returns {void}
+     * 
+     * @memberof Context
+     */
     strokePixel(i,j) {
         if(!this.pixelInsideClip(i,j)) return;
         var new_pixel = this.calculateRGBA_stroke(i,j);
@@ -124,6 +292,18 @@ class Context {
         var final_pixel = this.composite(i,j,old_pixel,new_pixel);
         this.bitmap.setPixelRGBA(i,j,final_pixel);
     }
+
+    /**
+     * Fill Pixel With Color
+     * 
+     * @param {number} i 
+     * @param {number} j
+     * @param {number} col
+     * 
+     * @returns {void}
+     * 
+     * @memberof Context
+     */
     fillPixelWithColor(i,j,col) {
         if(!this.pixelInsideClip(i,j)) return;
         var new_pixel = col;
@@ -132,6 +312,18 @@ class Context {
         this.bitmap.setPixelRGBA(i,j,final_pixel);
     }
 
+    /**
+     * Composite
+     * 
+     * @param {number} i
+     * @param {number} j
+     * @param {number} old_pixel
+     * @param {number} new_pixel
+     * 
+     * @returns {void}
+     * 
+     * @memberof Context
+     */
     composite(i,j,old_pixel, new_pixel) {
         const old_rgba = uint32.getBytesBigEndian(old_pixel);
         const new_rgba = uint32.getBytesBigEndian(new_pixel);
@@ -153,24 +345,86 @@ class Context {
         //convert back to int
         return uint32.fromBytesBigEndian(Cf[0],Cf[1],Cf[2],Cf[3]);
     }
+
+    /**
+     * Calculate RGBA
+     * 
+     * @param {number} x X position
+     * @param {number} y Y position
+     * 
+     * @returns {number}
+     * 
+     * @memberof Context
+     */
     calculateRGBA(x,y) {
         return this._fillColor;
     }
+
+    /**
+     * Calculate RGBA Stroke
+     * 
+     * @param {number} x X position
+     * @param {number} y Y position
+     * 
+     * @returns {number}
+     * 
+     * @memberof Context
+     */
     calculateRGBA_stroke(x,y) {
         return this._strokeColor;
     }
 
 
-    //get set image data
+    /**
+     * Get Image Data
+     * 
+     * @param {number} x X position
+     * @param {number} y Y position
+     * @param {number} w Width
+     * @param {number} h Height
+     * 
+     * @returns {Bitmap}
+     * 
+     * @memberof Context
+     */
     getImageData(x,y,w,h) {
-        // console.log("pretending to do something");
         return this.bitmap;
     }
+
+    /**
+     * @ignore
+     * 
+     * *Put Image Data
+     * 
+     * @param {number} id Image ID
+     * @param {number} x X position
+     * @param {number} y Y position
+     * 
+     * @returns {void}
+     * 
+     * @memberof Context
+     */
     putImageData(id, x, y) {
-        // console.log("pretending to do something");
+        throw new ("Method not yet implemented");
     }
 
-
+    /**
+     * Draw Image
+     * 
+     * @param {Bitmap} bitmap An instance of the {@link Bitmap} class to use for drawing
+     * @param {number} sx
+     * @param {number} sy
+     * @param {number} sw
+     * @param {number} sh
+     * @param {number} dx
+     * @param {number} dy
+     * @param {number} dw
+     * @param {number} dh
+     * 
+     * @returns {void}
+     * 
+     * @memberof Context
+     */
     drawImage(bitmap, sx,sy,sw,sh, dx, dy, dw, dh) {
         for(var i=0; i<dw; i++) {
             var tx = i/dw;
@@ -185,32 +439,133 @@ class Context {
     }
 
 
-    // paths
+    /**
+     * Begin Path
+     * 
+     * Initialize the `path` attribue to hold the path points
+     * 
+     * @returns {void}
+     * 
+     * @memberof Context
+     */
     beginPath() {
+        /**
+         * @type {Array}
+         */
         this.path = [];
     }
+
+    /**
+     * Move the "pen" to a given point specified by `x` and `y`. API sugar for {@link _moveTo}
+     * 
+     * @param {number} x X position
+     * @param {number} y Y position 
+     * 
+     * @returns {void}
+     * 
+     * @memberof Context
+    * */
     moveTo(x,y) {
         return this._moveTo({x:x,y:y});
     }
+
+    /**
+     * Move the "pen" to a given point
+     * 
+     * @param {object} pt A `point` object representing a set of co-ordinates to move the "pen" to.
+     * @example this._moveTo({x: 20, y: 40})
+     * 
+     * @returns {void}
+     * 
+     * @memberof Context
+    * */
     _moveTo(pt) {
         pt = this.transform.transformPoint(pt);
+        /**
+         * @type {object}
+         */
         this.pathstart = pt;
         this.path.push(['m',pt]);
     }
+
+    /**
+     * Line To
+     * 
+     * @param {number} x X position
+     * @param {number} y Y position
+     * 
+     * @returns {void}
+     * 
+     * @memberof Context
+     */
     lineTo(x,y) {
         return this._lineTo({x:x, y:y});
     }
+
+    /**
+     * Line To
+     * 
+     * @param {{x: 20, y: 52}} pt A point object to draw a line to from the current set of co-ordinates
+     * 
+     * @returns {void}
+     * 
+     * @memberof Context
+     */
     _lineTo(pt) {
         this.path.push(['l',this.transform.transformPoint(pt)]);
     }
+
+    /**
+     * Quadratic Curve To
+     * 
+     * Create a quadratic curve
+     * 
+     * @param {number} cp1x Curve point X position
+     * @param {number} cp1y Curve point Y position
+     * @param {number} x Curve X position
+     * @param {number} y Curve Y position
+     * 
+     * @returns {void}
+     * 
+     * @memberof Context
+     */
     quadraticCurveTo(cp1x, cp1y, x,y) {
         let cp1 = this.transform.transformPoint({x:cp1x, y:cp1y});
         let pt = this.transform.transformPoint({x:x, y:y});
         this.path.push(['q', cp1, pt]);
     }
+
+    /**
+     * Bezier Curve To
+     * 
+     * Create a bezier curve betweeen two points
+     * 
+     * @param {number} cp1x Curve point 1 X position
+     * @param {number} cp1y Curve point 1 Y position
+     * @param {number} cp2x Curve point 2 X position
+     * @param {number} cp2y Curve point 2 Y position
+     * @param {number} x Curve X position
+     * @param {number} y Curve Y position
+     * 
+     * @returns {void}
+     * 
+     * @memberof Context
+     */
     bezierCurveTo(cp1x, cp1y, cp2x, cp2y, x, y) {
         this._bezierCurveTo({x:cp1x,y:cp1y},{x:cp2x,y:cp2y}, {x:x,y:y});
     }
+
+    /**
+     * Bezier Curve To
+     * 
+     * @param {number} cp1 Curve point 1
+     * @param {number} cp2 Curve point 2
+     * @param {number} pt 
+     * 
+     * @returns {void}
+     * 
+     * @memberof Context
+    * */
     _bezierCurveTo(cp1, cp2, pt) {
         cp1 = this.transform.transformPoint(cp1);
         cp2 = this.transform.transformPoint(cp2);
@@ -218,6 +573,20 @@ class Context {
         this.path.push(['b', cp1, cp2, pt]);
     }
 
+    /**
+     * Arc
+     * 
+     * @param {number} x X position
+     * @param {number} y Y position
+     * @param {number} rad Arc radius
+     * @param {number} start Arc start
+     * @param {number} end Arc end
+     * @param {boolean} clockwise Set arc direction (`true` for clockwise, `false` for anti-clockwise)
+     * 
+     * @returns {void}
+     * 
+     * @memberof Context
+     */
     arc(x,y, rad, start, end, clockwise) {
         function calcPoint(ctx,type,angle) {
             let px = x + Math.sin(angle)*rad;
@@ -230,34 +599,109 @@ class Context {
         }
         this._lineTo(calcPoint(this,'l',end));
     }
+
+    /**
+     * Arc To
+     * 
+     * @throws {Error} Method is not yet implemented
+     * 
+     * @memberof Context
+     */
     arcTo() {
         throw new Error("arcTo not yet supported");
     }
+
+    /**
+     * Rect
+     * 
+     * @throws {Error} Method is not yet implemented
+     * 
+     * @memberof Context
+     */
     rect() {
         throw new Error("rect not yet supported");
     }
+
+    /**
+     * Ellipse
+     * 
+     * @throws {Error} Method is not yet implemented
+     * 
+     * @memberof Context
+     */
     ellipse() {
         throw new Error("ellipse not yet supported");
     }
+
+    /**
+     * Clip
+     * 
+     * @returns {void}
+     * 
+     * @memberof Context
+     */
     clip() {
         this._clip = pathToLines(this.path);
     }
+
+    /**
+     * Measure Text
+     * 
+     * @throws {Error} Method is not yet implemented
+     * 
+     * @memberof Context
+     */
     measureText() {
         throw new Error("measureText not yet supported");
     }
 
+    /**
+     * Close Path
+     * 
+     * @returns {void}
+     * 
+     * @memberof Context
+     */
     closePath() {
         this.path.push(['l',this.pathstart]);
     }
 
 
-    //stroke and fill paths
+    /**
+     * Stroke
+     * 
+     * @returns {void}
+     * 
+     * @memberof Context
+     */
     stroke() {
         pathToLines(this.path).forEach((line)=> this.drawLine(line));
     }
+
+    /**
+     * Draw Line
+     * 
+     * @param {{start: {x: 42, y: 30}, end: {x: 10, y: 20}}} line A set of co-ordinates representing the start and end of the line
+     * 
+     * @returns {void}
+     * 
+     * @memberof Context
+     */
     drawLine(line) {
         this.imageSmoothingEnabled?this.drawLine_aa(line):this.drawLine_noaa(line)
     }
+
+    /**
+     * Draw Line NoAA
+     * 
+     * Draw a line with anti-aliasing disabled
+     * 
+     * @param {{start: {x: 42, y: 30}, end: {x: 10, y: 20}}} line A set of co-ordinates representing the start and end of the line
+     * 
+     * @returns {void}
+     * 
+     * @memberof Context
+     */
     drawLine_noaa(line) {
         //Bresenham's from Rosetta Code
         // http://rosettacode.org/wiki/Bitmap/Bresenham's_line_algorithm#JavaScript
@@ -277,8 +721,17 @@ class Context {
             if (e2 < dy) { err += dx; y0 += sy; }
         }
     }
-    // antialiased Bresenham's line with width
-    // http://members.chello.at/~easyfilter/bresenham.html
+    
+    /**
+     * Draw Line Anti-aliased
+     * 
+     * Anti-aliased Bressenham's line with width
+     * 
+     * @see http://members.chello.at/~easyfilter/bresenham.html
+     * 
+     * @param {{start: {x: 42, y: 30}, end: {x: 10, y: 20}}} line A set of co-ordinates representing the start and end of the line
+     * @memberof Context
+     */
     drawLine_aa(line) {
         let width = this._lineWidth;
         let x0 = Math.floor(line.start.x);
@@ -317,9 +770,24 @@ class Context {
         }
     }
 
+    /**
+     * Fill
+     * 
+     * @returns {void}
+     * 
+     * @memberof Context
+     */
     fill() {
         this.imageSmoothingEnabled ? this.fill_aa() : this.fill_noaa();
     }
+
+    /**
+     * Fill Anti-aliased
+     * 
+     * @returns {void}
+     * 
+     * @memberof Context
+     */
     fill_aa() {
         //get just the color part
         var rgb = uint32.and(this._fillColor,0xFFFFFF00);
@@ -356,6 +824,14 @@ class Context {
             }
         }
     }
+
+    /**
+     * Fill No Anti-aliased
+     * 
+     * @returns {void}
+     * 
+     * @memberof Context
+     */
     fill_noaa() {
         //get just the color part
         var rgb = uint32.and(this._fillColor, 0xFFFFFF00);
@@ -382,11 +858,24 @@ class Context {
                 }
             }
         }
-    }
+    } 
 
-    //even/odd rule. https://en.wikipedia.org/wiki/Point_in_polygon
-    //technically this is not correct as the default algorithm for
-    //html canvas is supposed to be the non-zero winding rule instead
+    /**
+     * Pixel Inside Clip
+     * 
+     * Even/odd rule. https://en.wikipedia.org/wiki/Point_in_polygon
+     * technically this is not correct as the default algorithm for
+     * html canvas is supposed to be the non-zero winding rule instead
+     * 
+     * @see https://en.wikipedia.org/wiki/Point_in_polygon
+     *  
+     * @param {number} i
+     * @param {number} j
+     * 
+     * @returns {void}
+     *  
+     * @memberof Context
+     */
     pixelInsideClip(i,j) {
         if(!this._clip) return true;
         // console.log("checking for clip",i,j,this._clip);
@@ -407,11 +896,49 @@ class Context {
 
 
 
-    //stroke and fill text
+    /**
+     * Fill Text
+     * 
+     * @param {string} text The text to fill
+     * @param {number} x X position
+     * @param {number} y Y position
+     * 
+     * @returns {void}
+     * 
+     * @memberof Context
+     */
     fillText(text, x ,y) { TEXT.processTextPath(this, text, x,y, true);  }
+
+    /**
+     * Stroke Text
+     * 
+     * @param {string} text The text to stroke
+     * @param {number} x X position
+     * @param {number} y Y position
+     * 
+     * @returns {void}
+     * 
+     * @memberof Context
+     */
     strokeText(text, x ,y) { TEXT.processTextPath(this, text, x,y, false);  }
 
 
+    /**
+     * Color String To Unint32
+     * 
+     * Convert a color string to Uint32 notation
+     * 
+     * @static
+     * @param {number} str The color string to convert
+     * 
+     * @returns {number}
+     * 
+     * @example 
+     * var uInt32 = colorStringToUint32('#FF00FF');
+     * console.log(uInt32); // Prints 4278255615
+     * 
+     * @memberof Context
+     */
     static colorStringToUint32(str) {
         if(!str) return 0x000000;
         //hex values always get 255 for the alpha channel
@@ -442,13 +969,33 @@ class Context {
 }
 module.exports = Context;
 
-
+/**
+ * Fract
+ * 
+ * @param {number} v
+ * 
+ * @returns {number}
+ */
 function fract(v) {  return v-Math.floor(v);   }
 
-
+/**
+ * Make Line
+ * 
+ * @param {number} start
+ * @param {number} end
+ * 
+ * @returns {{start: start, end: end}}
+ */
 function makeLine  (start,end) {  return {start:start, end:end} }
 
-
+/**
+ * Path to Lines
+ * 
+ * Convert a path of points to an array of lines
+ * 
+ * @param {Array} path 
+ * @returns 
+ */
 function pathToLines(path) {
     var lines = [];
     var curr = null;
@@ -481,19 +1028,41 @@ function pathToLines(path) {
     return lines;
 }
 
+/**
+ * Calculate Quadratic
+ * 
+ * @param {number} p
+ * @param {number} t
+ * 
+ * @returns {void} 
+ */
 function calcQuadraticAtT(p, t) {
     var x = (1-t)*(1-t)*p[0].x + 2*(1-t)*t*p[1].x + t*t*p[2].x;
     var y = (1-t)*(1-t)*p[0].y + 2*(1-t)*t*p[1].y + t*t*p[2].y;
     return {x:x,y:y};
 }
 
+/**
+ * Calculate Bezier at T
+ * 
+ * @param {number} p
+ * @param {number} t
+ * 
+ * @returns {void}
+ */
 function calcBezierAtT(p, t) {
     var x = (1-t)*(1-t)*(1-t)*p[0].x + 3*(1-t)*(1-t)*t*p[1].x + 3*(1-t)*t*t*p[2].x + t*t*t*p[3].x;
     var y = (1-t)*(1-t)*(1-t)*p[0].y + 3*(1-t)*(1-t)*t*p[1].y + 3*(1-t)*t*t*p[2].y + t*t*t*p[3].y;
     return {x:x,y:y};
 }
 
-
+/**
+ * Calculate Minimum Bounds
+ * 
+ * @param {Array} lines
+ * 
+ * @returns {{x: Number.MAX_VALUE, y: Number.MAX_VALUE, x2: Number.MIN_VALUE, y2: Number.MIN_VALUE}}
+ */
 function calcMinimumBounds(lines) {
     var bounds = {  x:  Number.MAX_VALUE, y:  Number.MAX_VALUE,  x2: Number.MIN_VALUE, y2: Number.MIN_VALUE }
     function checkPoint(pt) {
@@ -510,7 +1079,18 @@ function calcMinimumBounds(lines) {
 }
 
 
-//adapted from http://alienryderflex.com/polygon
+/**
+ * Calculate Sorted Intersections
+ * 
+ * Adopted from http://alienryderflex.com/polygon
+ * 
+ * @see http://alienryderflex.com/polygon
+ * 
+ * @param {Array} lines An {@link Array} of Lines
+ * @param {number} y 
+ * 
+ * @returns {Array}
+ */
 function calcSortedIntersections(lines,y) {
     var xlist = [];
     for(var i=0; i<lines.length; i++) {
@@ -525,8 +1105,31 @@ function calcSortedIntersections(lines,y) {
 }
 
 
-
+/**
+ * Lerp
+ * 
+ * In mathematics, linear interpolation is a method of curve fitting using linear polynomials to construct new data
+ * points within the range of a discrete set of known data points.
+ * 
+ * @param {number} a 
+ * @param {number} b 
+ * @param {number} t 
+ * 
+ * @see https://en.wikipedia.org/wiki/Linear_interpolation
+ * 
+ * @returns {number}
+ */
 function lerp(a,b,t) {  return a + (b-a)*t; }
+
+/**
+ * Clamp
+ * 
+ * @param {number} v 
+ * @param {number} min 
+ * @param {number} max 
+ * 
+ * @returns {number}
+ */
 function clamp(v,min,max) {
     if(v < min) return min;
     if(v > max) return max;

--- a/src/context.js
+++ b/src/context.js
@@ -397,8 +397,8 @@ class Context {
      * *Put Image Data
      * 
      * @param {number} id Image ID
-     * @param {number} x X position
-     * @param {number} y Y position
+     * @param {number} x  X position
+     * @param {number} y  Y position
      * 
      * @returns {void}
      * 
@@ -473,6 +473,7 @@ class Context {
      * Move the "pen" to a given point
      * 
      * @param {object} pt A `point` object representing a set of co-ordinates to move the "pen" to.
+     * 
      * @example this._moveTo({x: 20, y: 40})
      * 
      * @returns {void}
@@ -522,8 +523,8 @@ class Context {
      * 
      * @param {number} cp1x Curve point X position
      * @param {number} cp1y Curve point Y position
-     * @param {number} x Curve X position
-     * @param {number} y Curve Y position
+     * @param {number} x    Curve X position
+     * @param {number} y    Curve Y position
      * 
      * @returns {void}
      * 
@@ -544,8 +545,8 @@ class Context {
      * @param {number} cp1y Curve point 1 Y position
      * @param {number} cp2x Curve point 2 X position
      * @param {number} cp2y Curve point 2 Y position
-     * @param {number} x Curve X position
-     * @param {number} y Curve Y position
+     * @param {number} x    Curve X position
+     * @param {number} y    Curve Y position
      * 
      * @returns {void}
      * 
@@ -576,11 +577,11 @@ class Context {
     /**
      * Arc
      * 
-     * @param {number} x X position
-     * @param {number} y Y position
-     * @param {number} rad Arc radius
-     * @param {number} start Arc start
-     * @param {number} end Arc end
+     * @param {number}  x         X position
+     * @param {number}  y         Y position
+     * @param {number}  rad       Arc radius
+     * @param {number}  start     Arc start
+     * @param {number}  end       Arc end
      * @param {boolean} clockwise Set arc direction (`true` for clockwise, `false` for anti-clockwise)
      * 
      * @returns {void}
@@ -900,8 +901,8 @@ class Context {
      * Fill Text
      * 
      * @param {string} text The text to fill
-     * @param {number} x X position
-     * @param {number} y Y position
+     * @param {number} x    X position
+     * @param {number} y    Y position
      * 
      * @returns {void}
      * 
@@ -913,8 +914,8 @@ class Context {
      * Stroke Text
      * 
      * @param {string} text The text to stroke
-     * @param {number} x X position
-     * @param {number} y Y position
+     * @param {number} x    X position
+     * @param {number} y    Y position
      * 
      * @returns {void}
      * 

--- a/src/named_colors.js
+++ b/src/named_colors.js
@@ -1,8 +1,12 @@
 /**
- * Created by josh on 8/21/16.
+ * @enum {string}
  */
 var NAMED_COLORS = {
-    'white':0xFFFFFFff, 'black':0x000000ff,  'red':0xFF0000ff,  'green':0x00FF00ff, 'blue':0x0000FFff,
+    'white': 0xFFFFFFff,
+    'black': 0x000000ff,
+    'red'  : 0xFF0000ff,
+    'green': 0x00FF00ff,
+    'blue' : 0x0000FFff
 }
 
 module.exports = NAMED_COLORS;

--- a/src/named_colors.js
+++ b/src/named_colors.js
@@ -1,4 +1,5 @@
 /**
+ * Enumeration containing popular colors
  * @enum {string}
  */
 var NAMED_COLORS = {

--- a/src/pureimage.js
+++ b/src/pureimage.js
@@ -36,7 +36,7 @@ exports.make = function(w,h,options) {
 /**
  * Encode the PNG image to output stream
  * 
- * @param {Bitmap} bitmap An instance of {@link Bitmap} to be encoded to PNG
+ * @param {Bitmap} bitmap    An instance of {@link Bitmap} to be encoded to PNG
  * @param {Stream} outstream The stream to write the PNG file to
  * 
  * @returns {Promise}
@@ -71,7 +71,7 @@ exports.encodePNGToStream = function(bitmap, outstream) {
  * 
  * Encode the JPEG image to output stream
  *  
- * @param {string} img An object containing a raw buffer of the image data (`img.buffer`) along with the width(`img.width`) and height (`img.height`) of the image
+ * @param {string} img       An object containing a raw buffer of the image data (`img.buffer`) along with the width(`img.width`) and height (`img.height`) of the image
  * @param {Stream} outstream The stream to write the JPEG file to
  * @returns {Promise<object>}
  */

--- a/src/pureimage.js
+++ b/src/pureimage.js
@@ -5,18 +5,42 @@
 //2014-11-15  line count: 401, 399, 386, 369, 349,
 
 
+/** @ignore */
 var fs = require('fs');
+/** @ignore */
 var PNG = require('pngjs').PNG;
+/** @ignore */
 var JPEG = require('jpeg-js');
+/** @ignore */
 var uint32 = require('./uint32');
+/** @ignore */
 var Bitmap = require('./bitmap');
+/** @ignore */
 var text = require('./text');
 
-
+/**
+ * Make
+ * 
+ * Create a new bitmap image
+ * 
+ * @param w Image width
+ * @param h Image height
+ * @param options Options to be passed to {@link Bitmap}
+ * 
+ * @returns {Bitmap}
+ */
 exports.make = function(w,h,options) {
     return new Bitmap(w,h,options);
 };
 
+/**
+ * Encode the PNG image to output stream
+ * 
+ * @param {Bitmap} bitmap An instance of {@link Bitmap} to be encoded to PNG
+ * @param {Stream} outstream The stream to write the PNG file to
+ * 
+ * @returns {Promise}
+ */
 exports.encodePNGToStream = function(bitmap, outstream) {
     return new Promise((res,rej)=>{
         var png = new PNG({
@@ -42,6 +66,15 @@ exports.encodePNGToStream = function(bitmap, outstream) {
     });
 }
 
+/**
+ * Encode JPEG To Stream
+ * 
+ * Encode the JPEG image to output stream
+ *  
+ * @param {string} img An object containing a raw buffer of the image data (`img.buffer`) along with the width(`img.width`) and height (`img.height`) of the image
+ * @param {Stream} outstream The stream to write the JPEG file to
+ * @returns {Promise<object>}
+ */
 exports.encodeJPEGToStream = function(img, outstream) {
     return new Promise((res,rej)=> {
         var data = {
@@ -54,6 +87,15 @@ exports.encodeJPEGToStream = function(img, outstream) {
     });
 };
 
+/**
+ * Decode JPEG From Stream
+ * 
+ * Decode a JPEG image from an incoming stream of data
+ * 
+ * @param {Stream} data A readable stream to decode JPEG data from
+ * 
+ * @returns {Promise<Bitmap>}
+ */
 exports.decodeJPEGFromStream = function(data) {
     return new Promise((res,rej)=>{
         try {
@@ -85,6 +127,15 @@ exports.decodeJPEGFromStream = function(data) {
     });
 };
 
+/**
+ * Decode PNG From Stream
+ * 
+ * Decode a PNG file from an incoming readable stream
+ * 
+ * @param {Stream} instream A readable stream containing raw PNG data
+ * 
+ * @returns {Promise<Bitmap>}
+ */
 exports.decodePNGFromStream = function(instream) {
     return new Promise((res,rej)=>{
         instream.pipe(new PNG())
@@ -98,5 +149,5 @@ exports.decodePNGFromStream = function(instream) {
     })
 };
 
-
+/**@ignore */
 exports.registerFont = text.registerFont;

--- a/src/pureimage.js
+++ b/src/pureimage.js
@@ -23,9 +23,9 @@ var text = require('./text');
  * 
  * Create a new bitmap image
  * 
- * @param w Image width
- * @param h Image height
- * @param options Options to be passed to {@link Bitmap}
+ * @param {number} w       Image width
+ * @param {number} h       Image height
+ * @param {object} options Options to be passed to {@link Bitmap}
  * 
  * @returns {Bitmap}
  */

--- a/src/text.js
+++ b/src/text.js
@@ -1,11 +1,27 @@
+/** @ignore */
 var opentype = require('opentype.js');
 
+
 /**
- * Created by josh on 7/2/17.
+ * @type {object} Map containing all the fonts available for use
  */
 var _fonts = { };
+
+/**
+ * The default font family to use for text
+ * @type {string}
+ */
 const DEFAULT_FONT_FAMILY = 'source';
 
+/**
+ * Register Font
+ * 
+ * @param {string} binaryPath Path to the font binary file
+ * @param {string} family The name to give the font
+ * @param {number} weight The font weight to use
+ * @param {string} style Font style
+ * @param {string} variant Font variant
+ */
 exports.registerFont = function(binaryPath, family, weight, style, variant) {
     _fonts[family] = {
         binary: binaryPath,
@@ -31,14 +47,35 @@ exports.registerFont = function(binaryPath, family, weight, style, variant) {
     };
     return _fonts[family];
 };
+/**@ignore */
 exports.debug_list_of_fonts = _fonts;
 
+/**
+ * Find Font
+ * 
+ * Search the `fonts` array for a given font family name
+ * 
+ * @param {string} family The name of the font family to search for
+ * 
+ * @returns {object}
+ */
 function findFont(family) {
     if(_fonts[family]) return _fonts[family];
     family =  Object.keys(_fonts)[0];
     return _fonts[family];
 }
 
+/**
+ * Process Text Path
+ * 
+ * @param {Context} ctx The context to write to
+ * @param {string} text The text to write to the given Context
+ * @param {number} x X position
+ * @param {number} y Y position
+ * @param {boolean} fill Indicates wether or not the font should be filled
+ * 
+ * @returns {void}
+ */
 exports.processTextPath = function(ctx,text,x,y, fill) {
     let font = findFont(ctx._font.family);
     var size = ctx._font.size;
@@ -77,6 +114,14 @@ exports.processTextPath = function(ctx,text,x,y, fill) {
     }
 };
 
+/**
+ * Process Text Path
+ * 
+ * @param {Context} ctx The canvas context on which to measure the text
+ * @param {string} text The name to give the font
+ * 
+ * @returns {object}
+ */
 exports.measureText = function(ctx,text) {
     var font = _fonts[ctx._settings.font.family];
     if(!font) console.log("WARNING. Can't find font family ", ctx._settings.font.family);

--- a/src/text.js
+++ b/src/text.js
@@ -17,10 +17,10 @@ const DEFAULT_FONT_FAMILY = 'source';
  * Register Font
  * 
  * @param {string} binaryPath Path to the font binary file
- * @param {string} family The name to give the font
- * @param {number} weight The font weight to use
- * @param {string} style Font style
- * @param {string} variant Font variant
+ * @param {string} family     The name to give the font
+ * @param {number} weight     The font weight to use
+ * @param {string} style      Font style
+ * @param {string} variant    Font variant
  */
 exports.registerFont = function(binaryPath, family, weight, style, variant) {
     _fonts[family] = {
@@ -68,10 +68,10 @@ function findFont(family) {
 /**
  * Process Text Path
  * 
- * @param {Context} ctx The context to write to
- * @param {string} text The text to write to the given Context
- * @param {number} x X position
- * @param {number} y Y position
+ * @param {Context} ctx  The context to write to
+ * @param {string}  text The text to write to the given Context
+ * @param {number}  x    X position
+ * @param {number}  y    Y position
  * @param {boolean} fill Indicates wether or not the font should be filled
  * 
  * @returns {void}

--- a/src/transform.js
+++ b/src/transform.js
@@ -9,7 +9,9 @@
  */
 
 "use strict";
-
+/**
+ * @ignore
+ */
 function Transform(context) {
     this.context = context;
     this.matrix = [1,0,0,1,0,0]; //initialize with the identity matrix


### PR DESCRIPTION
**PR Overview**
Adds docblock annotations to the following files: 
- [`src/bitmap.js`](https://github.com/robertmain/node-pureimage/blob/esdoc/src/bitmap.js)  
- [`src/context.js`](https://github.com/robertmain/node-pureimage/blob/esdoc/src/context.js)  
- [`src/named_colors.js`](https://github.com/robertmain/node-pureimage/blob/esdoc/src/named_colors.js)  
- [`src/text.js`](https://github.com/robertmain/node-pureimage/blob/esdoc/src/pureimage.js)  

Omitted docblock annotations for: 
- [`src/transform.js`](https://github.com/robertmain/node-pureimage/blob/esdoc/src/transform.js)
- [`src/uint32.js`](https://github.com/robertmain/node-pureimage/blob/esdoc/src/uint32.js)

since they seem to be vendor code, and the latter was choking the ESdoc compiler. Maybe they could move into the `vendor` folder for separation?

---

**To Test**
1. Run `npm install --dev` to install dev dependencies(the documentation generator etc.)
1. Run `npm run-script docs` to generate a set of documentation in `./docs`

Ref #32 