### PR TITLE
Only deploy documentation once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,8 @@ deploy:
   skip_cleanup: true
   github_token: $GITHUB_TOKEN
   on:
-    branch: master
+    repo: joshmarinacci/node-pureimage
+    branches:
+      only:
+        - master
+    node_js: '8'


### PR DESCRIPTION
The docs are currently deployed once by each individual build job. So..3 build jobs(the tests are run against 3 different versions of node - 7, 8 and the most recent)...produces 3 documentation deployments.

![image](https://user-images.githubusercontent.com/537684/34897658-381fe8da-f7bd-11e7-929f-453ddb28705f.png)

The idea is to clean this up so that the documentation is only deployed if:

- The branch is `master`
- It's Node.js v8
- The build is being run from the `joshmarinacci/node-pureimage` repo

This should result in the docs only being deployed once :)