### PR TITLE
Contribution templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,32 @@
+### Expected Behaviour
+
+1.
+
+### Actual Behaviour
+
+1.
+
+### Steps To Reproduce
+
+1.
+
+### Any Relevant Code Snippets
+
+<!-- Please try to separate code snippets out for clarity -->
+
+```js
+
+```
+
+### Platform
+**OS:**
+**Node Version:**
+**NPM Version:**
+**PureImage Version:**
+
+### Any Additional Info
+<!--
+Use this section to record any additional info you think might be helpful(for example a proposed
+solution). Screenshots are also appreciated if applicable, as well as a minimal example demonstrating
+the issue.
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+## Types of changes
+
+<!--
+What types of changes does your code introduce? Put an `x` in all the boxes that apply
+ -->
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+
+## Checklist
+
+<!--
+Go over all the following points, and put an `x` in all the boxes that apply.
+If you're unsure about any of these, don't hesitate to ask. We're here to help!
+-->
+
+- [ ] My code follows the code style of this project.
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.
+- [ ] I have added tests to cover my changes.
+- [ ] All new and existing tests passed.
+
+## Description
+
+<!--
+Describe your changes here as well and any potential areas of interest you may wish to draw attention to
+-->
+
+
+
+
+<!--
+PR Template copied(and modified) from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
+-->


### PR DESCRIPTION
Add contribution templates to the repo to provide a standardised way to document issues and pull requests.

Examples below are from one of my own repos:

### Issue Template
![image](https://user-images.githubusercontent.com/537684/35360464-c9aec984-012b-11e8-922c-ade282454c86.png)

![image](https://user-images.githubusercontent.com/537684/35360474-d5a67066-012b-11e8-997a-fd4241ea1853.png)

### Pull Request Template

![image](https://user-images.githubusercontent.com/537684/35360523-ffd7d1b8-012b-11e8-97e1-2f8f26925a12.png)

![image](https://user-images.githubusercontent.com/537684/35360533-07b9e9ac-012c-11e8-9f56-decfdd3a5a35.png)
