### PR TITLE
Speed up Build Time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: false
+dist: trusty
 language: node_js
 node_js:
     - "node"


### PR DESCRIPTION
Since this library does not require the usage of `sudo` on Travis, we can run it on the faster infrastructure which boots in ~1s rather than 20-50s