### PR TITLE
fix(text): fix fonts checking path

### DIFF
--- a/src/text.js
+++ b/src/text.js
@@ -124,9 +124,9 @@ exports.processTextPath = function(ctx,text,x,y, fill) {
  * @returns {object}
  */
 exports.measureText = function(ctx,text) {
-    var font = _fonts[ctx._settings.font.family];
-    if(!font) console.log("WARNING. Can't find font family ", ctx._settings.font.family);
-    var fsize   = ctx._settings.font.size;
+    var font = _fonts[ctx._font.family];
+    if(!font) console.log("WARNING. Can't find font family ", ctx._font.family);
+    var fsize   = ctx._font.size;
     var glyphs  = font.font.stringToGlyphs(text);
     var advance = 0;
     glyphs.forEach(function(g) { advance += g.advanceWidth; });


### PR DESCRIPTION
## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
 -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Description

<!--
Describe your changes here as well and any potential areas of interest you may wish to draw attention to
-->

Hi,

After my custom font loaded, I needed to use your method `mesureText` from the file `src/text.js` in order to make a textAlign center. Because this text feature is still not available in your great library for the moment. So at that moment I got an exception about a wrong object path in the context object to access fonts.
So this pullRequest is just a small bug fixing :)

I hope you will continue to develop this library very useful for me to avoid to install all node-canvas dependencies.

Best regards

<!--
PR Template copied(and modified) from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
