### PR TITLE
encodePNGToStream - resolve Promise on finish

### DIFF
--- a/src/pureimage.js
+++ b/src/pureimage.js
@@ -47,11 +47,12 @@ exports.encodePNGToStream = function(bitmap, outstream) {
             }
         }
 
-        png.on('finish', ()=>{  res(); })
+        png
             .on('error', (err) => { rej(err); })
             .pack()
             .pipe(outstream)
-            
+            .on('finish', () => { res(); })
+            .on('error', (err) => { rej(err); });
     });
 }
 


### PR DESCRIPTION
## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
 -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] My code follows the code style of this project. (at least I thnk so :P)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Description

<!--
Describe your changes here as well and any potential areas of interest you may wish to draw attention to
-->
Node: 10.15.1
OS: Windows 10

Commit a9889768fbb40f3ec531bb5f64bfbb8c467a7599 introduced bug where Promise returned by "encodePNGToStream" was never being resolved. It also caused some tests to fail.

Pull request I'm proposing fixes issue by moving 'finish' listener from PNG file to outstream. It also copies 'error' handler to outstream (just in case).

<!--
PR Template copied(and modified) from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
