### PR TITLE
Context.composite - mixing RGB and taking more opaque alpha

### DIFF
--- a/src/context.js
+++ b/src/context.js
@@ -443,22 +443,27 @@ class Context {
         const old_rgba = uint32.getBytesBigEndian(old_pixel);
         const new_rgba = uint32.getBytesBigEndian(new_pixel);
 
-        //convert to range of 0->1
-        const A = new_rgba.map((b)=>b/255);
-        const B = old_rgba.map((b)=>b/255);
-        //multiply by global alpha
-        A[3] = A[3]*this._globalAlpha;
+        // convert to range of 0->1
+        const A = new_rgba.map((b) => b / 255);
+        const B = old_rgba.map((b) => b / 255);
 
-        //do a standard composite (SRC_OVER)
-        function compit(ca,cb,aa,ab) {
+        // multiply by global alpha
+        A[3] = A[3] * this._globalAlpha;
+
+        // do a standard composite (SRC_OVER) on RGB values
+        function compit(ca, cb, aa, ab) {
             return (ca*aa + cb*ab * (1-aa)) / (aa+ab*(1-aa));
         }
-        const C = A.map((comp,i)=> compit(A[i],B[i],A[3],B[3]));
+        const C = A.slice(0, 3).map((comp, i) => compit(A[i], B[i], A[3], B[3]));
 
-        //convert back to 0->255 range
-        const Cf = C.map((c)=>c*255);
-        //convert back to int
-        return uint32.fromBytesBigEndian(Cf[0],Cf[1],Cf[2],Cf[3]);
+        // convert back to 0->255 range
+        const Cf = C.map((c) => c * 255);
+
+        // convert back to int
+        return uint32.fromBytesBigEndian(
+            Cf[0], Cf[1], Cf[2], // R, G, B,
+            Math.max(old_rgba[3], new_rgba[3]) // alpha
+        );
     }
 
     /**


### PR DESCRIPTION
## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
 -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed. (or more precisely, it does not cause any of test fails)

## Description

<!--
Describe your changes here as well and any potential areas of interest you may wish to draw attention to
-->

Context.composite is mixing RGBA values (including alpha).
When fillText is used on an opaque background, the semi-transparent parts of generated text are affecting transparency of background in that areas.

Below image was generated by code from commit 9b49a703105c051c7a03b9db62d8c72d4e8d7635
![current_render](https://user-images.githubusercontent.com/1501990/53290663-af340980-37a7-11e9-95b3-647d2ccdc948.png)
If you open it in program that shows transparency and zoom in, you will see that image became transparent in places where text was transparent.

Fix proposed in my pull request causes Context.composite to mix only RGB values and for resulting pixel's alpha the higher alpha value is taken.

After this fix:

![fix_render](https://user-images.githubusercontent.com/1501990/53290699-1782eb00-37a8-11e9-9d7c-b317337e5e1c.png)

In this pull request there are also some readability improvements (in my opinion). If you don't like them let me know and I'll get rid of them.

Added close up screen shot from GIMP. Left shows current behaviour, right shows behaviour after the fix:
![close_up](https://user-images.githubusercontent.com/1501990/53291522-bad9fd00-37b4-11e9-86c6-c87135ca47b1.PNG)

<!--
PR Template copied(and modified) from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
