### PR TITLE
Adding "loadSync" method to font object for loading fonts synchronously.

### DIFF
--- a/src/text.js
+++ b/src/text.js
@@ -44,6 +44,14 @@ exports.registerFont = function(binaryPath, family, weight, style, variant) {
                 self.font = font;
                 if(cb)cb();
             });
+        },
+        loadSync: function() {
+            if(this.loaded) {
+                return;
+            }
+            this.loaded = true;
+            this.font = opentype.loadSync(binaryPath);
+            return this;
         }
     };
     return _fonts[family];

--- a/src/text.js
+++ b/src/text.js
@@ -49,9 +49,13 @@ exports.registerFont = function(binaryPath, family, weight, style, variant) {
             if(this.loaded) {
                 return;
             }
-            this.loaded = true;
-            this.font = opentype.loadSync(binaryPath);
-            return this;
+            try {
+                this.font = opentype.loadSync(binaryPath);
+                this.loaded = true;
+                return this;
+            } catch (err) {
+                throw new Error('Could not load font: ' + err);
+            }
         }
     };
     return _fonts[family];


### PR DESCRIPTION
## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
 -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the code style of this project.

## Description
Ended up editing this repository to implement this because the api for load() was awkward when used in a server-side node application where code dependent on the loaded font immediately followed calling "registerFont".

I noticed opentype exposes a "loadSync" function already anyway.

This is very straightforward and I would imagine, at least naively, that this should not impact anything else in the project.