### PR TITLE
returning self when font is already loaded.

### DIFF
--- a/src/text.js
+++ b/src/text.js
@@ -47,7 +47,7 @@ exports.registerFont = function(binaryPath, family, weight, style, variant) {
         },
         loadSync: function() {
             if(this.loaded) {
-                return;
+                return this;
             }
             try {
                 this.font = opentype.loadSync(binaryPath);


### PR DESCRIPTION
## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.

## Description

Because of how loadSync is expected to work for the person using it, it needs to return self when a font has already been loaded.
