### PR TITLE
Handle bad JPEG data

### DIFF
--- a/src/pureimage.js
+++ b/src/pureimage.js
@@ -102,7 +102,12 @@ exports.decodeJPEGFromStream = function(data) {
             data.on('data', chunk => chunks.push(chunk));
             data.on('end',() => {
                 var buf = Buffer.concat(chunks);
-                var rawImageData = JPEG.decode(buf);
+                try {
+                    var rawImageData = JPEG.decode(buf);
+                } catch(err) {
+                    rej(err);
+                    return
+                }
                 var bitmap = new Bitmap(rawImageData.width, rawImageData.height);
                 for (var x_axis = 0; x_axis < rawImageData.width; x_axis++) {
                     for (var y_axis = 0; y_axis < rawImageData.height; y_axis++) {

--- a/tests/unit/specs/pureimage.test.js
+++ b/tests/unit/specs/pureimage.test.js
@@ -119,6 +119,15 @@ describe('JPEG image', () => {
         });
     });
 
+    /**
+     * @test {decodeJPEGFromStream}
+     */
+    it('rejects invalid JPEG data', () => {
+        return expect(
+            pureimage.decodeJPEGFromStream(fs.createReadStream(__dirname + '/pureimage.test.js'))
+        ).rejects.toThrow("SOI not found");
+    });
+
     afterEach(() => {
         PImage  = undefined;
         context = undefined;


### PR DESCRIPTION
## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Description

In testing I found that passing a Buffer with garbage data in to `pureimage.decodeJPEGFromStream` was causing an Uncaught Exception to be thrown:

```
29 Oct 15:05:13 - [red] Uncaught Exception:
29 Oct 15:05:13 - Error: SOI not found
    at constructor.parse (/Users/nol/code/node-red/node-red-nodes/utility/annotate-image/node_modules/jpeg-js/lib/decoder.js:628:15)
    at Object.decode (/Users/nol/code/node-red/node-red-nodes/utility/annotate-image/node_modules/jpeg-js/lib/decoder.js:1096:11)
    at Readable.data.on (/Users/nol/code/node-red/node-red-nodes/utility/annotate-image/node_modules/pureimage/src/pureimage.js:108:41)
    at Readable.emit (events.js:198:13)
    at endReadableNT (_stream_readable.js:1145:12)
    at process._tickCallback (internal/process/next_tick.js:63:19)
```

Having stepped through the code, I can see that when `JPEG.decode` throws the error there was nothing there to catch it.

This fix adds a try/catch around the call to decode and ensures the enclosing promise is properly rejected with the error.

On the question of tests, from a clean checkout of the `master` branch, I have one test failing that is unrelated to the change I've made.
```
  ● drawing gradients › is making a radial gradient

    expect(received).toBe(expected) // Object.is equality

    Expected value to be:
      16711935
    Received:
      8388863
```
