### PR TITLE
fix fill_aa method that starting and ending pixel don`t have origin alpha infomation

### DIFF
--- a/src/context.js
+++ b/src/context.js
@@ -998,6 +998,7 @@ class Context {
         if(!this._closed) this.closePath()
         //get just the color part
         var rgb = uint32.and(this._fillColor,0xFFFFFF00);
+        var alpha = uint32.and(this._fillColor,0xFF);
         var lines = pathToLines(this.path);
         var bounds = calcMinimumBounds(lines);
 
@@ -1016,13 +1017,13 @@ class Context {
                 for(var ii=start; ii<=end; ii++) {
                     if(ii == start) {
                         //first
-                        var int = uint32.or(rgb,(1-fstartf)*255);
+                        var int = uint32.or(rgb,(1-fstartf)*alpha);
                         this.fillPixelWithColor(ii,j, int);
                         continue;
                     }
                     if(ii == end) {
                         //last
-                        var int = uint32.or(rgb,fendf*255);
+                        var int = uint32.or(rgb,fendf*alpha);
                         this.fillPixelWithColor(ii,j, int);
                         continue;
                     }


### PR DESCRIPTION
fix fill_aa method that starting and ending pixel don`t have origin alpha infomation

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
 -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Description

<!--
Describe your changes here as well and any potential areas of interest you may wish to draw attention to
-->

when imageSmoothingEnabled is true(default) fillText with color have low alpha,it have some points not use the base alpha.
![image](https://user-images.githubusercontent.com/9784030/100441552-9d506a80-30e1-11eb-9fe5-14ff93eb49c9.png)
I don't konw the real way to do.Just  multiply it.



<!--
PR Template copied(and modified) from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
