### PR TITLE
Add `drawImage` overloads to types

### DIFF
--- a/types/context.d.ts
+++ b/types/context.d.ts
@@ -390,6 +390,8 @@ export class Context {
         dw: number,
         dh: number
     ): void;
+    drawImage(bitmap: Bitmap, dx: number, dy: number): void;
+    drawImage(bitmap: Bitmap, dx: number, dy: number, dWidth: number, dHeight: number): void;
 
     /**
      * Starts a new path by emptying the list of sub-paths. Call this method when you want to create a new path.


### PR DESCRIPTION
## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
 -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Description

Only the longest shape of `drawImage` was described in the types before, this PR adds [the two short overloads](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/drawImage) as well:

```javascript
void ctx.drawImage(image, dx, dy);
void ctx.drawImage(image, dx, dy, dWidth, dHeight);
void ctx.drawImage(image, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight);
```
