### PR TITLE
feat: export all text.js methods

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import {PNG} from "pngjs"
 import * as JPEG from "jpeg-js"
 import {getBytesBigEndian} from './uint32.js'
 
-export {registerFont} from './text.js'
+export * from './text.js'
 
 export function make (w,h,options) {
     return new Bitmap(w,h,options)


### PR DESCRIPTION
## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Description

node-pureimage is a nice lib, It make my work easier

I need measureText, however,
In my environment (I cant change it)
I only use way of commonJs module to export method
but, node-pureimage only support esModule import measureText
So I export all text.js methods

Pls approve my request

<!--
PR Template copied(and modified) from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
