### PR TITLE
Fixes text placement inconsistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ font.load(() => {
 ```
 
 produces
+
 ![stream example](./images/streamexample.png)
 
 The same as above but with Promises

--- a/src/context.js
+++ b/src/context.js
@@ -197,12 +197,8 @@ export class Context {
      * @example ctx.globalAlpha = 1;
      */
     set font(val) {
-        const n = val.trim().indexOf(' ')
-        const font_size = parseInt(val.slice(0, n))
-        const font_name = val.slice(n).trim()
-
-        this._font.family = font_name;
-        this._font.size   = font_size;
+        this._font.family = val.family.trim();
+		this._font.size = val.size.trim();
     }
 
 

--- a/src/context.js
+++ b/src/context.js
@@ -198,7 +198,7 @@ export class Context {
      */
     set font(val) {
         this._font.family = val.family.trim();
-		this._font.size = val.size.trim();
+		this._font.size = val.size;
     }
 
 


### PR DESCRIPTION
## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
 -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Description

<!--
Describe your changes here as well and any potential areas of interest you may wish to draw attention to
-->

The "produces" text seems to be placed accidentally inline with the image, instead of before the image.

The rest of the README also had the "produces" text placed before the image that will be shown, which looks great.


<!--
PR Template copied(and modified) from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
