### PR TITLE
Fix 151: fillRect() doesn't use transforms

### DIFF
--- a/.run/clean.run.xml
+++ b/.run/clean.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="clean" type="js.build_tools.npm" nameIsGenerated="true">
+    <package-json value="$PROJECT_DIR$/package.json" />
+    <command value="run" />
+    <scripts>
+      <script value="clean" />
+    </scripts>
+    <node-interpreter value="project" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/test.run.xml
+++ b/.run/test.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="test" type="js.build_tools.npm" nameIsGenerated="true">
+    <package-json value="$PROJECT_DIR$/package.json" />
+    <command value="run" />
+    <scripts>
+      <script value="test" />
+    </scripts>
+    <node-interpreter value="project" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>

--- a/src/bitmap.js
+++ b/src/bitmap.js
@@ -73,6 +73,10 @@ export class Bitmap {
      * @memberof Bitmap
      */
     setPixelRGBA(x,y,rgba) {
+        if(x < 0) return
+        if(y < 0) return
+        if(x >= this.width) return
+        if(y >= this.height) return
         let i = this.calculateIndex(x, y);
         const bytes = getBytesBigEndian(rgba);
         this.data[i+0] = bytes[0];

--- a/src/bitmap.js
+++ b/src/bitmap.js
@@ -1,4 +1,4 @@
-import {NAMED_COLORS} from "./named_colors.js"
+import {NAMED_COLORS, OPAQUE_BLACK} from "./named_colors.js"
 import {Context} from "./context.js"
 import {fromBytesBigEndian, getBytesBigEndian} from './uint32.js'
 
@@ -35,7 +35,9 @@ export class Bitmap {
          */
         this.data = Buffer.alloc(w*h*4);
 
-        const fillval = NAMED_COLORS.transparent
+        // per the spec, fill it with opaque black
+        // https://html.spec.whatwg.org/multipage/canvas.html#output-bitmap
+        const fillval = OPAQUE_BLACK
         for(let j=0; j<h; j++) {
             for (let i = 0; i < w; i++) {
                 this.setPixelRGBA(i, j, fillval);
@@ -73,10 +75,7 @@ export class Bitmap {
      * @memberof Bitmap
      */
     setPixelRGBA(x,y,rgba) {
-        if(x < 0) return
-        if(y < 0) return
-        if(x >= this.width) return
-        if(y >= this.height) return
+        this.validate_coords(x,y)
         let i = this.calculateIndex(x, y);
         const bytes = getBytesBigEndian(rgba);
         this.data[i+0] = bytes[0];
@@ -118,6 +117,7 @@ export class Bitmap {
      * @memberof Bitmap
      */
     getPixelRGBA(x,y) {
+        this.validate_coords(x,y)
         let i = this.calculateIndex(x, y);
         return fromBytesBigEndian(
             this.data[i+0],
@@ -180,4 +180,18 @@ export class Bitmap {
         }
     }
 
+    _isValidCoords(x,y) {
+        if(x<0) return false
+        if(y<0) return false
+        if(x>=this.width) return false
+        if(y>=this.height) return false
+        return true
+    }
+
+    validate_coords(x, y) {
+        if(x<0) throw new Error(`Invalid Index: x ${x} <0`)
+        if(y<0) throw new Error(`Invalid Index: y ${y} <0`)
+        if(x>=this.width) throw new Error(`Invalid Index: x ${x} >= width ${this.width}`)
+        if(y>=this.height) throw new Error(`Invalid Index: x ${x} >= width ${this.height}`)
+    }
 }

--- a/src/context.js
+++ b/src/context.js
@@ -330,10 +330,21 @@ export class Context {
      * @memberof Context
      */
     fillRect(x,y,w,h) {
-        for(let i=x; i<x+w; i++) {
-            for(let j=y; j<y+h; j++) {
-                this.fillPixelWithColor(i,j,this.calculateRGBA(i,j))
+        if(this._transform.isIdentity()) {
+            for (let i = x; i < x + w; i++) {
+                for (let j = y; j < y + h; j++) {
+                    this.fillPixelWithColor(i, j, this.calculateRGBA(i, j))
+                }
             }
+        } else {
+            let old_path = this.path
+            let old_closed = this._closed
+            this.beginPath()
+            this.rect(x-0.0001, y-0.0001, w, h)
+            this.closePath()
+            this.fill()
+            this.path = old_path
+            this._closed = old_closed
         }
     }
 

--- a/src/context.js
+++ b/src/context.js
@@ -1,7 +1,7 @@
 "use strict";
 
 import {Line} from "./line.js"
-import {NAMED_COLORS} from './named_colors.js'
+import {NAMED_COLORS, TRANSPARENT_BLACK} from './named_colors.js'
 import {Bounds, calc_min_bounds, Point, toDeg, toRad} from "./point.js"
 import * as TEXT from "./text.js"
 import * as trans from "./transform.js"
@@ -332,7 +332,7 @@ export class Context {
     fillRect(x,y,w,h) {
         for(let i=x; i<x+w; i++) {
             for(let j=y; j<y+h; j++) {
-                this.fillPixel(i,j);
+                this.fillPixelWithColor(i,j,this.calculateRGBA(i,j))
             }
         }
     }
@@ -354,7 +354,7 @@ export class Context {
     clearRect(x,y,w,h) {
         for(let i=x; i<x+w; i++) {
             for(let j=y; j<y+h; j++) {
-                this.bitmap.setPixelRGBA(i,j,0x00000000);
+                this.bitmap.setPixelRGBA(i,j,TRANSPARENT_BLACK);
             }
         }
     }
@@ -398,11 +398,10 @@ export class Context {
         if(!this.pixelInsideClip(x,y)) {
             return
         }
-
+        if(!this.bitmap._isValidCoords(x,y)) return
         const new_pixel = this.calculateRGBA(x, y)
         const old_pixel = this.bitmap.getPixelRGBA(x, y)
         const final_pixel = this.composite(x, y, old_pixel, new_pixel)
-
         this.bitmap.setPixelRGBA(x,y,final_pixel);
     }
 
@@ -446,6 +445,7 @@ export class Context {
             return
         }
 
+        if(!this.bitmap._isValidCoords(x,y)) return
         const new_pixel = col
         const old_pixel = this.bitmap.getPixelRGBA(x, y)
         const final_pixel = this.composite(x, y, old_pixel, new_pixel)
@@ -622,7 +622,7 @@ export class Context {
                 )
                 if(src_bounds.contains(src_pt)) {
                     const rgba = bitmap.getPixelRGBA(src_pt.x, src_pt.y)
-                    if(this.pixelInsideClip(dst_pt.x,dst_pt.y)) {
+                    if(this.pixelInsideClip(dst_pt.x,dst_pt.y) && this.bitmap._isValidCoords(dst_pt.x,dst_pt.y)) {
                         this.bitmap.setPixelRGBA(dst_pt.x, dst_pt.y, rgba)
                     }
                 }

--- a/src/named_colors.js
+++ b/src/named_colors.js
@@ -154,3 +154,7 @@ export const NAMED_COLORS = {
     yellowgreen: 0x9acd32ff
 }
 
+export const TRANSPARENT_BLACK = 0x00000000
+export const OPAQUE_BLACK = 0x000000FF
+
+

--- a/src/transform.js
+++ b/src/transform.js
@@ -11,6 +11,8 @@
 "use strict";
 import {Point} from './point.js'
 
+const IDENTITY_MATRIX = [1,0,0,1,0,0];
+
 /**
  * @ignore
  */
@@ -154,9 +156,16 @@ export function Transform(context) {
     }
 
     this.identity = function() {
-        this.m = [1,0,0,1,0,0];
+        this.m = IDENTITY_MATRIX
         this.setTransform();
     };
+
+    this.isIdentity = function() {
+        for(let i=0; i<this.matrix.length; i++) {
+            if(this.matrix[i] !== IDENTITY_MATRIX[i]) return false
+        }
+        return true
+    }
 
     this.multiply = function(matrix) {
         const m11 = this.matrix[0] * matrix[0] + this.matrix[2] * matrix[1]

--- a/test/clipping.test.js
+++ b/test/clipping.test.js
@@ -1,10 +1,8 @@
 import chai, {expect} from "chai"
 
 import * as pureimage from "../src/index.js"
-import fs from 'fs'
-import path from 'path'
-import {write_png} from './common.js'
 import {OPAQUE_BLACK} from '../src/named_colors.js'
+import {save} from './common.js'
 
 describe('clipping tests',() => {
     let image
@@ -21,19 +19,20 @@ describe('clipping tests',() => {
     })
 
     it('can fill with white and red', (done) => {
+        // fill whole canvas with white
         context.fillStyle = 'white';
         context.fillRect(0, 0, 200, 200);
+        // create a circle
         context.beginPath();
         context.arc(100,100, 50, 0, Math.PI*2,false)
+        // use circle as clip
         context.clip();
+        // now fill with red
         context.fillStyle = 'red';
         context.fillRect(0, 0, 200, 200);
-        write_png(image,'clipcolor').then(()=>{
-            console.log("wrote out clipcolor.png")
-            expect(image.getPixelRGBA(0, 0)).to.eq(0xFFFFFFFF)
-            expect(image.getPixelRGBA(100,100)).to.eq(0xFF0000FF)
-            done()
-        })
+        expect(image.getPixelRGBA(0, 0)).to.eq(0xFFFFFFFF)
+        expect(image.getPixelRGBA(100,100)).to.eq(0xFF0000FF)
+        save(image,'clipcolor',done)
     })
 
     it('can draw an image inside of a clip',(done)=>{
@@ -51,12 +50,10 @@ describe('clipping tests',() => {
         c.fillStyle = 'black'
         c.fillRect(25,0,25,50)
         context.drawImage(src,75,75,50,50)
-        write_png(image,'clipimage').then(()=>{
-            expect(image.getPixelRGBA(0, 0)).to.eq(0xFF0000FF)
-            expect(image.getPixelRGBA(99, 100)).to.eq(0xFFFFFFFF)
-            expect(image.getPixelRGBA(80, 100)).to.eq(0xFF0000FF)
-            done()
-        })
+        expect(image.getPixelRGBA(0, 0)).to.eq(0xFF0000FF)
+        expect(image.getPixelRGBA(99, 100)).to.eq(0xFFFFFFFF)
+        expect(image.getPixelRGBA(80, 100)).to.eq(0xFF0000FF)
+        save(image,'clipimage',done)
     })
 
     it('can save and restore clips',(done) => {

--- a/test/clipping.test.js
+++ b/test/clipping.test.js
@@ -4,6 +4,7 @@ import * as pureimage from "../src/index.js"
 import fs from 'fs'
 import path from 'path'
 import {write_png} from './common.js'
+import {OPAQUE_BLACK} from '../src/named_colors.js'
 
 describe('clipping tests',() => {
     let image
@@ -15,7 +16,7 @@ describe('clipping tests',() => {
     })
 
     it('canvas is empty and clear', (done) => {
-        expect(image.getPixelRGBA(0, 0)).to.eq(0x00000000)
+        expect(image.getPixelRGBA(0, 0)).to.eq(OPAQUE_BLACK)
         done()
     })
 

--- a/test/color.test.js
+++ b/test/color.test.js
@@ -1,6 +1,7 @@
 import chai, {expect} from "chai"
 
 import * as pureimage from "../src/index.js"
+import {OPAQUE_BLACK} from '../src/named_colors.js'
 
 describe('color',() => {
     let image
@@ -12,7 +13,7 @@ describe('color',() => {
     })
 
     it('canvas is empty and clear', (done) => {
-        expect(image.getPixelRGBA(0,0)).to.eq(0x00000000)
+        expect(image.getPixelRGBA(0,0)).to.eq(OPAQUE_BLACK)
         done()
     })
 

--- a/test/common.js
+++ b/test/common.js
@@ -20,3 +20,15 @@ export function write_png (image,filename) {
     let stream = fs.createWriteStream(pth);
     return pureimage.encodePNGToStream(image, stream)
 }
+
+const DIR = "output"
+
+export function save(image, filename, done) {
+    mkdir(DIR).then(()=>{
+        let pth = path.join(DIR, filename)
+        pureimage.encodePNGToStream(image, fs.createWriteStream(pth)).then(() => {
+            console.log(`wrote out ${pth}`)
+            done()
+        })
+    }).catch(e => console.error(e))
+}

--- a/test/common.js
+++ b/test/common.js
@@ -25,7 +25,7 @@ const DIR = "output"
 
 export function save(image, filename, done) {
     mkdir(DIR).then(()=>{
-        let pth = path.join(DIR, filename)
+        let pth = path.join(DIR, filename+".png")
         pureimage.encodePNGToStream(image, fs.createWriteStream(pth)).then(() => {
             console.log(`wrote out ${pth}`)
             done()

--- a/test/drawimage.test.js
+++ b/test/drawimage.test.js
@@ -19,7 +19,7 @@ describe('drawImage',() => {
     })
 
     it('canvas is empty and clear', (done) => {
-        expect(image.getPixelRGBA(0,0)).to.eq(0x00000000)
+        expect(image.getPixelRGBA(0,0)).to.eq(0x000000FF)
         done()
     })
 

--- a/test/gradientfill.test.js
+++ b/test/gradientfill.test.js
@@ -24,10 +24,9 @@ describe('drawing gradients',() => {
         grad.addColorStop(1,'blue')
         c.fillStyle = grad
         c.fillRect(0,0,20,20)
-
         expect(image.getPixelRGBA(0, 0)).to.eq(0xFFFFFFFF)
         expect(image.getPixelRGBA(19, 19)).to.eq(0x0C0CFFFF)
-        save(image, 'linear_gradient_fillrect.png',done)
+        save(image, 'linear_gradient_fillrect',done)
     })
 
     it('fill with linear gradient',(done)=>{

--- a/test/gradientfill.test.js
+++ b/test/gradientfill.test.js
@@ -1,18 +1,8 @@
-import chai, {expect} from "chai"
+import {expect} from "chai"
 import * as pureimage from "../src/index.js"
-import fs from "fs"
-import path from "path";
-import {NAMED_COLORS} from "../src/named_colors.js";
+import {NAMED_COLORS} from "../src/named_colors.js"
+import {save} from './common.js'
 
-const DIR = "output"
-
-function save(image, filename, done) {
-    let pth = path.join(DIR,filename)
-    pureimage.encodePNGToStream(image, fs.createWriteStream(pth)).then(() => {
-        console.log(`wrote out ${pth}`)
-        done()
-    }).catch(e => console.error(e))
-}
 describe('drawing gradients',() => {
 
     let image

--- a/test/path.test.js
+++ b/test/path.test.js
@@ -1,18 +1,6 @@
 import chai, {expect} from "chai"
 import * as pureimage from "../src/index.js"
-import fs from "fs"
-import path from "path"
 import {save} from './common.js'
-const DIR = "output"
-const mkdir = (pth) => {
-    return new Promise((res,rej)=>{
-        fs.mkdir(pth,(e)=>{
-            // console.log("done with mkdir",e)
-            res()
-        })
-    })
-}
-mkdir(DIR)
 describe('draw curve',() => {
 
     let image;

--- a/test/path.test.js
+++ b/test/path.test.js
@@ -2,6 +2,7 @@ import chai, {expect} from "chai"
 import * as pureimage from "../src/index.js"
 import fs from "fs"
 import path from "path"
+import {save} from './common.js'
 const DIR = "output"
 const mkdir = (pth) => {
     return new Promise((res,rej)=>{
@@ -59,7 +60,6 @@ describe('draw curve',() => {
         done()
     })
 
-    //draw bezier curve
     it('bezier curve', (done) => {
         c.fillStyle = 'white'
         c.fillRect(0,0,200,200)
@@ -70,16 +70,9 @@ describe('draw curve',() => {
         c.bezierCurveTo(50,50, 100,50, 10,100)
         c.lineTo(10,10)
         c.fill()
-        pureimage.encodePNGToStream(image, fs.createWriteStream(path.join(DIR,'bezier1.png'))).then(() => {
-            console.log('wrote out bezier1.png')
-            expect(image.getPixelRGBA(0, 0)).to.eq(WHITE)
-            expect(image.getPixelRGBA(19, 39)).to.eq(BLACK)
-            done()
-        })
-
-        // expect(image.getPixelRGBA(0,0)).to.eq(WHITE)
-        // expect(image.getPixelRGBA(20,15)).to.eq(BLACK)
-        // done()
+        expect(image.getPixelRGBA(0, 0)).to.eq(WHITE)
+        expect(image.getPixelRGBA(19, 39)).to.eq(BLACK)
+        save(image,'bezier1',done)
     })
 
     it('arc', (done) => {
@@ -114,10 +107,7 @@ describe('draw curve',() => {
                 }
             }
         }
-        pureimage.encodePNGToStream(img, fs.createWriteStream(path.join(DIR,'arc.png'))).then(()=>{
-            console.log('wrote out arc.png')
-            done()
-        })
+        save(img,'arc',done)
     })
     it('north going polygon', (done) => {
         let img = pureimage.make(200, 200);
@@ -131,13 +121,9 @@ describe('draw curve',() => {
         ctx.lineTo(20,120)
         ctx.lineTo(20,50)
         ctx.fill();
-        pureimage.encodePNGToStream(img, fs.createWriteStream(path.join(DIR,'northgoing.png'))).then(()=>{
-            console.log('wrote out northgoing.png')
-            expect(img.getPixelRGBA(25, 110)).to.eq(BLACK)
-            expect(img.getPixelRGBA(25, 90)).to.eq(BLACK)
-            done()
-        })
-
+        expect(img.getPixelRGBA(25, 110)).to.eq(BLACK)
+        expect(img.getPixelRGBA(25, 90)).to.eq(BLACK)
+        save(img,"northgoing",done)
     })
     it('transparent polygon',(done)=>{
         c.beginPath()
@@ -152,9 +138,6 @@ describe('draw curve',() => {
         expect(image.getPixelRGBA(11,11)).to.eq(WHITE)
         expect(image.getPixelRGBA(50,50)).to.eq(WHITE)
         expect(image.getPixelRGBA(100,100)).to.eq(WHITE)
-
-
-
         done()
     })
     it("draws thick square",(done) => {
@@ -175,17 +158,11 @@ describe('draw curve',() => {
         c.lineWidth = 4
         c.fillStyle = 'black'
         c.stroke()
-        // c.fillStyle = 'black'
-        // c.fill()
-        pureimage.encodePNGToStream(image, fs.createWriteStream(path.join(DIR,'thick_stroke_square.png'))).then(() => {
-            console.log('wrote out thick_stroke.png')
-            // expect(image.getPixelRGBA(0, 0)).to.eq(WHITE)
-            // expect(image.getPixelRGBA(19, 39)).to.eq(BLACK)
-            done()
-        })
+        expect(image.getPixelRGBA(0, 0)).to.eq(WHITE)
+        expect(image.getPixelRGBA(10, 10)).to.eq(BLACK)
+        save(image,'thick_stroke_square',done)
     })
     it('draws a thin horizontal line',(done) => {
-        let fname = "thin-h-stroke.png"
         let image = pureimage.make(10, 10);
         let c = image.getContext('2d');
         c.imageSmoothingEnabled = true
@@ -198,13 +175,9 @@ describe('draw curve',() => {
         c.strokeStyle = 'black'
         c.lineWidth = 1
         c.stroke()
-        pureimage.encodePNGToStream(image, fs.createWriteStream(path.join(DIR,fname))).then(() => {
-            console.log(`wrote out "${fname}"`)
-            // expect(image.getPixelRGBA(0, 0)).to.eq(WHITE)
-            // expect(image.getPixelRGBA(19, 39)).to.eq(BLACK)
-            done()
-        })
-
+        expect(image.getPixelRGBA(0, 0)).to.eq(WHITE)
+        expect(image.getPixelRGBA(5, 5)).to.eq(BLACK)
+        save(image,'think-h-stroke',done)
     })
     it("draws thick curve",(done) => {
         c.fillStyle = 'white'
@@ -218,28 +191,12 @@ describe('draw curve',() => {
         c.lineWidth = 2
         c.fillStyle = 'black'
         c.stroke()
-        // c.fillStyle = 'black'
-        // c.fill()
-        pureimage.encodePNGToStream(image, fs.createWriteStream(path.join(DIR,'thick_stroke_curve.png'))).then(() => {
-            console.log('wrote out thick_stroke.png')
-            // expect(image.getPixelRGBA(0, 0)).to.eq(WHITE)
-            // expect(image.getPixelRGBA(19, 39)).to.eq(BLACK)
-            done()
-        })
+        save(image,"thick_stroke_curve",done)
     })
-
     it('draws round rect',(done) => {
         create();
-
         let img = create();
-        pureimage.encodePNGToStream(img, fs.createWriteStream(path.join(DIR,'roundrect.png'))).then(() => {
-            console.log('wrote out roundrect.png')
-            done()
-        }).catch((e)=>{
-            console.log("there was an error writing");
-            console.log(e);
-        });
-
+        save(img,"roundrect",done)
         function create() {
             let img = pureimage.make(1200, 628)
             let ctx = img.getContext('2d')
@@ -329,9 +286,6 @@ describe('restroke test',() => {
         ctx.lineTo(280, 140);
         ctx.stroke();
 
-        pureimage.encodePNGToStream(image, fs.createWriteStream(path.join(DIR,'restroke.png'))).then(() => {
-            console.log('wrote out restroke.png')
-            done()
-        })
+        save(image,'restroke',done)
     })
 })

--- a/test/transforms.js
+++ b/test/transforms.js
@@ -1,8 +1,6 @@
 import * as pureimage from "../src/index.js"
 import chai, {expect} from "chai"
-import fs from 'fs'
-import path from 'path'
-import {mkdir, write_png} from './common.js'
+import {mkdir, save} from './common.js'
 
 
 describe("simple transforms",() => {
@@ -97,8 +95,7 @@ describe("simple transforms",() => {
         context.strokeStyle = 'black'
         context.stroke()
         context.restore();
-        write_png(image,'line_transform').then(done)
-
+        save(image,'line_transform',done)
     })
 
 })
@@ -130,11 +127,9 @@ describe("transform image",()=>{
 
     it('draws image normally',(done)=>{
         context.drawImage(src,0,0)
-        write_png(image,'image_plain').then(() => {
-            expect(image.getPixelRGBA(0, 0)).to.eq(0xFFFFFFFF)
-            expect(image.getPixelRGBA(25,0)).to.eq(0x000000FF)
-            done()
-        })
+        expect(image.getPixelRGBA(0, 0)).to.eq(0xFFFFFFFF)
+        expect(image.getPixelRGBA(25,0)).to.eq(0x000000FF)
+        save(image,'transform_image_plain',done)
     })
 
     it('draws image translated',(done)=>{
@@ -142,13 +137,9 @@ describe("transform image",()=>{
         context.translate(50,50)
         context.drawImage(src,0,0)
         context.restore()
-        write_png(image,'image_translated').then(()=>{
-            expect(image.getPixelRGBA(0+50, 0+50)).to.eq(0xFFFFFFFF)
-            expect(image.getPixelRGBA(25+50,0+50)).to.eq(0x000000FF)
-            done()
-        }).catch(e => {
-            console.error(e)
-        })
+        expect(image.getPixelRGBA(0+50, 0+50)).to.eq(0xFFFFFFFF)
+        expect(image.getPixelRGBA(25+50,0+50)).to.eq(0x000000FF)
+        save(image,'image_translated',done)
     })
 
     it('draws image scaled',(done)=>{
@@ -156,13 +147,9 @@ describe("transform image",()=>{
         context.scale(3,3)
         context.drawImage(src,0,0)
         context.restore()
-        write_png(image,'image_scaled').then(()=>{
-            expect(image.getPixelRGBA(0*3, 0*3)).to.eq(0xFFFFFFFF)
-            expect(image.getPixelRGBA(25*3,0*3)).to.eq(0x000000FF)
-            done()
-        }).catch(e => {
-            console.error(e)
-        })
+        expect(image.getPixelRGBA(0*3, 0*3)).to.eq(0xFFFFFFFF)
+        expect(image.getPixelRGBA(25*3,0*3)).to.eq(0x000000FF)
+        save(image,'image_scaled',done)
     })
 
     it('draws image rotated',(done)=>{
@@ -170,13 +157,9 @@ describe("transform image",()=>{
         context.rotate(-30*Math.PI/180)
         context.drawImage(src,0,0)
         context.restore()
-        write_png(image,'image_rotated').then(()=>{
-            expect(image.getPixelRGBA(10, 0)).to.eq(0xFFFFFFFF)
-            expect(image.getPixelRGBA(40,0)).to.eq(0x000000FF)
-            done()
-        }).catch(e => {
-            console.error(e)
-        })
+        expect(image.getPixelRGBA(10, 0)).to.eq(0xFFFFFFFF)
+        expect(image.getPixelRGBA(40,0)).to.eq(0x000000FF)
+        save(image,'image_rotated',done)
     })
 
     it('draws combined',(done)=>{
@@ -186,13 +169,9 @@ describe("transform image",()=>{
         context.translate(-25,-25)
         context.drawImage(src,0,0)
         context.restore()
-        write_png(image,'image_combined').then(()=>{
-            expect(image.getPixelRGBA(100, 103)).to.eq(0xFFFFFFFF)
-            expect(image.getPixelRGBA(100,97)).to.eq(0x000000FF)
-            done()
-        }).catch(e => {
-            console.error(e)
-        })
+        expect(image.getPixelRGBA(100, 103)).to.eq(0xFFFFFFFF)
+        expect(image.getPixelRGBA(100,97)).to.eq(0x000000FF)
+        save(image,'image_combined',done)
     })
 })
 
@@ -217,7 +196,7 @@ describe("transform rect",() => {
         expect(image.getPixelRGBA(0,   0)).to.eq(0xFF0000FF)
         expect(image.getPixelRGBA(10,  0)).to.eq(0xFFFFFFFF)
         expect(image.getPixelRGBA(10, 10)).to.eq(0xFF0000FF)
-        write_png(image,'transform_rect_plain').then(() => done())
+        save(image,'transform_rect_plain',done)
     })
 
     it("draws translated rects",(done)=>{
@@ -228,6 +207,6 @@ describe("transform rect",() => {
         // expect(image.getPixelRGBA(0,   0)).to.eq(0xFFFFFFFF)
         // expect(image.getPixelRGBA(10,  0)).to.eq(0xFF0000FF)
         // expect(image.getPixelRGBA(10, 10)).to.eq(0xFFFFFFFF)
-        write_png(image,'transform_rect_translate').then(() => done())
+        save(image,'transform_rect_translate',done)
     })
 })

--- a/test/transforms.js
+++ b/test/transforms.js
@@ -195,3 +195,39 @@ describe("transform image",()=>{
         })
     })
 })
+
+describe("transform rect",() => {
+    let image
+    let context
+
+    beforeEach(() => {
+        image = pureimage.make(20,20)
+        context = image.getContext('2d')
+        context.fillStyle = 'white'
+        context.fillRect(0,0,20,20)
+    })
+    function fillRect() {
+        context.fillStyle = 'red'
+        context.fillRect(0,0,10,10)
+        context.fillRect(10,10,10,10)
+    }
+
+    it("draws two rects",(done)=>{
+        fillRect()
+        expect(image.getPixelRGBA(0,   0)).to.eq(0xFF0000FF)
+        expect(image.getPixelRGBA(10,  0)).to.eq(0xFFFFFFFF)
+        expect(image.getPixelRGBA(10, 10)).to.eq(0xFF0000FF)
+        write_png(image,'transform_rect_plain').then(() => done())
+    })
+
+    it("draws translated rects",(done)=>{
+        context.save();
+        context.translate(5, 0);
+        fillRect()
+        context.restore();
+        // expect(image.getPixelRGBA(0,   0)).to.eq(0xFFFFFFFF)
+        // expect(image.getPixelRGBA(10,  0)).to.eq(0xFF0000FF)
+        // expect(image.getPixelRGBA(10, 10)).to.eq(0xFFFFFFFF)
+        write_png(image,'transform_rect_translate').then(() => done())
+    })
+})

--- a/test/transforms.js
+++ b/test/transforms.js
@@ -204,9 +204,9 @@ describe("transform rect",() => {
         context.translate(5, 0);
         fillRect()
         context.restore();
-        // expect(image.getPixelRGBA(0,   0)).to.eq(0xFFFFFFFF)
-        // expect(image.getPixelRGBA(10,  0)).to.eq(0xFF0000FF)
-        // expect(image.getPixelRGBA(10, 10)).to.eq(0xFFFFFFFF)
+        expect(image.getPixelRGBA(0,   0)).to.eq(0xFFFFFFFF)
+        expect(image.getPixelRGBA(10,  0)).to.eq(0xFF0000FF)
+        expect(image.getPixelRGBA(10, 10)).to.eq(0xFFFFFFFF)
         save(image,'transform_rect_translate',done)
     })
 })


### PR DESCRIPTION
make fillRect use the path() drawing instead of direct pixels when the current transform is not the identity transform.
makes the bitmap be filled with opaque black instead of transparent black
also updates some tests