### PR TITLE
Make getContext() on Bitmap function more like HTMLCanvasElement

### DIFF
--- a/src/bitmap.js
+++ b/src/bitmap.js
@@ -44,6 +44,7 @@ export class Bitmap {
             }
         }
 
+        this._context = new Context(this);
     }
 
     /**
@@ -144,14 +145,17 @@ export class Bitmap {
     }
 
     /**
-     * {@link Context} factory. Creates a new {@link Context} instance object for the current bitmap object
+     * Returns the {@link Context} instance object for the current bitmap object
      *
      * @returns {Context}
      *
      * @memberof Bitmap
      */
     getContext(type) {
-        return new Context(this);
+        if (type === "2d") {
+            return this._context;
+        }
+        return null;
     }
 
     _copySubBitmap(x,y,w,h) {

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -1,0 +1,24 @@
+import chai, {expect} from "chai"
+
+import * as pureimage from "../src/index.js"
+
+describe('context',() => {
+    let image
+    let context
+
+    beforeEach(() => {
+        image = pureimage.make(200,200)
+        context = image.getContext('2d')
+    })
+
+    it('getContext returns the same context', (done) => {
+        expect(image.getContext('2d')).to.eq(context)
+        done()
+    })
+
+    it('getContext returns null for invalid contextType', (done) => {
+        expect(image.getContext('this is totally made up')).to.eq(null)
+        done()
+    })
+
+})

--- a/types/bitmap.d.ts
+++ b/types/bitmap.d.ts
@@ -95,13 +95,13 @@ export class Bitmap {
     getPixelRGBA_separate(x: number, y: number): ArrayBuffer;
 
     /**
-     * {@link Context} factory. Creates a new {@link Context} instance object for the current bitmap object
+     * Returns the {@link Context} instance object for the current bitmap object
      *
      * @returns {Context}
      *
      * @memberof Bitmap
      */
-    getContext(type:string): Context;
+    getContext(type:string): Context | null;
 
     private _copySubBitmap(x: number, y: number, w: number, h: number): Bitmap;
 


### PR DESCRIPTION
## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
 -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Description

<!--
Describe your changes here as well and any potential areas of interest you may wish to draw attention to
-->
I'm trying to use the [canvas-text-wrapper](https://www.npmjs.com/package/canvas-text-wrapper) package to render text to a PureImage canvas. However, I'm running into the issue that it assumes getContext returns the same context each time so there is no way to configure settings like text color.

This PR changes getContext() on the Bitmap class to function more like the "real" one on [HTMLCanvasElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext). Specifically this behavior in the documentation:

> The HTMLCanvasElement.getContext() method returns a drawing context on the canvas, or null if the context identifier is not supported, or the canvas has already been set to a different context mode.
>
> Later calls to this method on the same canvas element, with the same contextType argument, will always return the same drawing context instance as was returned the first time the method was invoked.



<!--
PR Template copied(and modified) from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
