### PR TITLE
Composite pixels instead of overwriting in drawImage

### DIFF
--- a/src/context.js
+++ b/src/context.js
@@ -634,9 +634,11 @@ export class Context {
                     remap(src_pt.y, dy,dy+dh, sy,sy+sh)
                 )
                 if(src_bounds.contains(src_pt)) {
-                    const rgba = bitmap.getPixelRGBA(src_pt.x, src_pt.y)
                     if(this.pixelInsideClip(dst_pt.x,dst_pt.y) && this.bitmap._isValidCoords(dst_pt.x,dst_pt.y)) {
-                        this.bitmap.setPixelRGBA(dst_pt.x, dst_pt.y, rgba)
+                        const new_pixel = bitmap.getPixelRGBA(src_pt.x, src_pt.y)
+                        const old_pixel = this.bitmap.getPixelRGBA(dst_pt.x, dst_pt.y)
+                        const final_pixel = this.composite(0, 0, old_pixel, new_pixel)
+                        this.bitmap.setPixelRGBA(dst_pt.x, dst_pt.y, final_pixel)
                     }
                 }
             }


### PR DESCRIPTION
## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
 -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Description

This PR tries to fix #168.

The `drawImage` method currently just overwrites existing pixels with the pixels from the drawing image, including those transparent pixels, which seems to me is the *copy* operator according to this [document](https://drafts.fxtf.org/compositing/#porterduffcompositingoperators_src).

I'm not sure if this was intended or just a bug. But the default composition operator in canvas spec uses *source-over*, and the function `composite` in this library also uses *source-over*.

<!--
PR Template copied(and modified) from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
