### PR TITLE
fix bug #224: Bitmap constructor crash with float dimensions

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,0 +1,7 @@
+## 2026-07-08 11:09
+
+**Fix bug #224**: `Bitmap` constructor crash when float dimensions are passed to `make()`.
+
+In `src/bitmap.ts`, the constructor stored `Math.floor(w/h)` into `this.width/height` but then used the original float values for both the `Uint8Array` allocation and the fill loop. This caused `setPixelRGBA` to be called with `x = Math.floor(w)`, which equals `this.width`, triggering the `validate_coords` bounds check and throwing `Invalid Index: x N >= width N`.
+
+Fixed by using `this.width` and `this.height` consistently in place of the raw `w` and `h` floats after the floor assignment. Added `test/bugs/bug_224.test.ts` to cover this case.

--- a/src/bitmap.ts
+++ b/src/bitmap.ts
@@ -22,11 +22,11 @@ export class Bitmap {
   constructor(w: number, h: number) {
     this.width = Math.floor(w);
     this.height = Math.floor(h);
-    this.data = new Uint8Array(w * h * 4);
+    this.data = new Uint8Array(this.width * this.height * 4);
 
     const fillval = OPAQUE_BLACK;
-    for (let j = 0; j < h; j++) {
-      for (let i = 0; i < w; i++) {
+    for (let j = 0; j < this.height; j++) {
+      for (let i = 0; i < this.width; i++) {
         this.setPixelRGBA(i, j, fillval);
       }
     }

--- a/test/bugs/bug_224.test.ts
+++ b/test/bugs/bug_224.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import * as PImage from "../../src/index.js";
+
+describe("bug-224: make() with float dimensions should not crash", () => {
+    it("should construct without throwing when width and height are floats", () => {
+        expect(() => {
+            PImage.make(1100.000277777778, 849.9997222222221);
+        }).not.toThrow();
+    });
+
+    it("constructed bitmap should have integer width and height", () => {
+        const image = PImage.make(1100.000277777778, 849.9997222222221);
+        expect(image.width).toBe(1100);
+        expect(image.height).toBe(849);
+    });
+});


### PR DESCRIPTION
The constructor floored w/h into this.width/height but still used the raw float values for the Uint8Array allocation and fill loop. When the float was just above an integer (e.g. 1100.00027), the loop reached i=1100 which equaled this.width, causing validate_coords to throw "Invalid Index: x N >= width N". Fixed by using this.width/this.height consistently after the floor assignment. Added test/bugs/bug_224.test.ts.

fix for https://github.com/joshmarinacci/node-pureimage/issues/224

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
 -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Description

<!--
Describe your changes here as well and any potential areas of interest you may wish to draw attention to
-->

<!--
PR Template copied(and modified) from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
