### PR TITLE
fix font string parsing to support full CSS font shorthand syntax

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,15 @@
+## 2026-07-13 13:40
+
+**Fix font string parsing**: replaced the naive two-token font parser with a proper CSS font shorthand parser.
+
+The old `set font` split on the first space, so any string containing style/weight keywords (e.g. `"bold 12px Arial"`) would set `size = NaN` and store the full remainder as the family name.
+
+The new `parseFontString` function in `src/context.ts` iterates tokens left-to-right, recognising `style` (`italic`, `oblique`), `variant` (`small-caps`), `weight` (`bold`, `lighter`, `bolder`, and numeric 100–900) before the required size token (`<number><unit>`, where unit is `px`, `pt`, `em`, `rem`, etc.). Everything after the size token becomes the family name, with surrounding quotes stripped. Invalid or unrecognised input leaves `_font` unchanged rather than corrupting it.
+
+The `get font` getter is updated to reconstruct the full CSS font string from the stored properties (style → variant → weight → `${size}px` → family).
+
+Added `test/font-parsing.test.ts` with 39 unit tests covering: basic size/family (px, pt, em, rem, decimal sizes, quoted and space-separated family names), weight keywords and numeric weights, style keywords, variant, all combinations, getter round-trips, and edge cases (empty string, size-only, `normal` keyword, whitespace).
+
 ## 2026-07-08 11:09
 
 **Fix bug #224**: `Bitmap` constructor crash when float dimensions are passed to `make()`.

--- a/src/context.ts
+++ b/src/context.ts
@@ -18,6 +18,70 @@ import {
 import { clamp, colorStringToUint32 } from "./util.js";
 import { Matrix, Transform } from "./transform.js";
 
+// Matches a CSS size token: digits+optional-decimal followed by a unit, plus an optional /line-height suffix.
+const FONT_SIZE_RE = /^(\d*\.?\d+)(px|pt|em|rem|ex|ch|vw|vh|%)(\/.*)?$/i;
+const FONT_WEIGHT_KEYWORDS: Record<string, number> = { bold: 700, bolder: 800, lighter: 300 };
+
+type ParsedFont = {
+  size: number;
+  family: string;
+  style?: string;
+  variant?: string;
+  weight?: number;
+};
+
+function parseFontString(val: string): ParsedFont | null {
+  const tokens = val.trim().split(/\s+/);
+  let style: string | undefined;
+  let variant: string | undefined;
+  let weight: number | undefined;
+  let size: number | undefined;
+  let familyStart = 0;
+
+  for (let i = 0; i < tokens.length; i++) {
+    const lower = tokens[i].toLowerCase();
+
+    const sizeMatch = lower.match(FONT_SIZE_RE);
+    if (sizeMatch) {
+      size = parseFloat(sizeMatch[1]);
+      familyStart = i + 1;
+      break;
+    }
+
+    if ((lower === "italic" || lower === "oblique") && style === undefined) {
+      style = lower;
+      continue;
+    }
+    if (lower === "small-caps" && variant === undefined) {
+      variant = lower;
+      continue;
+    }
+    if (lower in FONT_WEIGHT_KEYWORDS && weight === undefined) {
+      weight = FONT_WEIGHT_KEYWORDS[lower];
+      continue;
+    }
+    if (/^\d+$/.test(lower) && weight === undefined) {
+      const n = parseInt(lower, 10);
+      if (n >= 100 && n <= 900) {
+        weight = n;
+        continue;
+      }
+    }
+    // unknown pre-size tokens (e.g. "normal") are skipped
+  }
+
+  if (size === undefined || familyStart > tokens.length) return null;
+
+  const family = tokens
+    .slice(familyStart)
+    .join(" ")
+    .replace(/['"]/g, "")
+    .trim();
+  if (!family) return null;
+
+  return { size, family, style, variant, weight };
+}
+
 /**
  * Used for drawing rectangles, text, images and other objects onto the canvas element. It provides the 2D rendering context for a drawing surface.
  *
@@ -119,14 +183,25 @@ export class Context {
    * @see https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/font
    */
   get font(): string {
-    return `${this._font.size} ${this._font.family}`;
+    const parts: string[] = [];
+    if (this._font.style) parts.push(this._font.style);
+    if (this._font.variant) parts.push(this._font.variant);
+    if (this._font.weight !== undefined) parts.push(String(this._font.weight));
+    parts.push(`${this._font.size}px`);
+    parts.push(this._font.family);
+    return parts.join(" ");
   }
 
-  /** @example ctx.font = '12 someFont'; */
+  /** @example ctx.font = 'bold italic 12px Arial'; */
   set font(val: string) {
-    const n = val.trim().indexOf(" ");
-    this._font.size = parseInt(val.slice(0, n));
-    this._font.family = val.slice(n).trim();
+    const parsed = parseFontString(val);
+    if (parsed) {
+      this._font.size = parsed.size;
+      this._font.family = parsed.family;
+      this._font.style = parsed.style;
+      this._font.variant = parsed.variant;
+      this._font.weight = parsed.weight;
+    }
   }
 
   /**

--- a/test/font-parsing.test.ts
+++ b/test/font-parsing.test.ts
@@ -1,0 +1,285 @@
+import { describe, beforeEach, it, expect } from "vitest";
+import * as pureimage from "../src/index.js";
+import { Context, Bitmap } from "../src/index";
+
+describe("font string parsing", () => {
+  let image: Bitmap;
+  let ctx: Context;
+
+  beforeEach(() => {
+    image = pureimage.make(100, 100);
+    ctx = image.getContext("2d");
+  });
+
+  describe("basic size and family", () => {
+    it("parses px size and unquoted family", () => {
+      ctx.font = "12px Arial";
+      expect(ctx._font.size).toBe(12);
+      expect(ctx._font.family).toBe("Arial");
+    });
+
+    it("parses pt size and unquoted family", () => {
+      ctx.font = "48pt Arial";
+      expect(ctx._font.size).toBe(48);
+      expect(ctx._font.family).toBe("Arial");
+    });
+
+    it("strips single quotes from family name", () => {
+      ctx.font = "48pt 'Source Sans Pro'";
+      expect(ctx._font.size).toBe(48);
+      expect(ctx._font.family).toBe("Source Sans Pro");
+    });
+
+    it("strips double quotes from family name", () => {
+      ctx.font = '14px "Times New Roman"';
+      expect(ctx._font.size).toBe(14);
+      expect(ctx._font.family).toBe("Times New Roman");
+    });
+
+    it("parses family name with spaces", () => {
+      ctx.font = "16px Helvetica Neue";
+      expect(ctx._font.size).toBe(16);
+      expect(ctx._font.family).toBe("Helvetica Neue");
+    });
+
+    it("parses em unit", () => {
+      ctx.font = "1.5em Georgia";
+      expect(ctx._font.size).toBe(1.5);
+      expect(ctx._font.family).toBe("Georgia");
+    });
+
+    it("parses rem unit", () => {
+      ctx.font = "2rem Verdana";
+      expect(ctx._font.size).toBe(2);
+      expect(ctx._font.family).toBe("Verdana");
+    });
+
+    it("parses decimal px size", () => {
+      ctx.font = "10.5px Arial";
+      expect(ctx._font.size).toBe(10.5);
+    });
+  });
+
+  describe("font weight", () => {
+    it("parses bold keyword as 700", () => {
+      ctx.font = "bold 12px Arial";
+      expect(ctx._font.weight).toBe(700);
+      expect(ctx._font.size).toBe(12);
+      expect(ctx._font.family).toBe("Arial");
+    });
+
+    it("parses lighter keyword as 300", () => {
+      ctx.font = "lighter 12px Arial";
+      expect(ctx._font.weight).toBe(300);
+    });
+
+    it("parses bolder keyword as 800", () => {
+      ctx.font = "bolder 12px Arial";
+      expect(ctx._font.weight).toBe(800);
+    });
+
+    it("parses numeric weight 400", () => {
+      ctx.font = "400 12px Arial";
+      expect(ctx._font.weight).toBe(400);
+    });
+
+    it("parses numeric weight 700", () => {
+      ctx.font = "700 14px Arial";
+      expect(ctx._font.weight).toBe(700);
+      expect(ctx._font.size).toBe(14);
+    });
+
+    it("parses numeric weight 600", () => {
+      ctx.font = "600 18px Arial";
+      expect(ctx._font.weight).toBe(600);
+    });
+
+    it("parses numeric weight 100", () => {
+      ctx.font = "100 12px Arial";
+      expect(ctx._font.weight).toBe(100);
+    });
+
+    it("parses numeric weight 900", () => {
+      ctx.font = "900 12px Arial";
+      expect(ctx._font.weight).toBe(900);
+    });
+
+    it("leaves weight undefined when not specified", () => {
+      ctx.font = "12px Arial";
+      expect(ctx._font.weight).toBeUndefined();
+    });
+  });
+
+  describe("font style", () => {
+    it("parses italic style", () => {
+      ctx.font = "italic 12px Arial";
+      expect(ctx._font.style).toBe("italic");
+      expect(ctx._font.size).toBe(12);
+      expect(ctx._font.family).toBe("Arial");
+    });
+
+    it("parses oblique style", () => {
+      ctx.font = "oblique 12px Arial";
+      expect(ctx._font.style).toBe("oblique");
+    });
+
+    it("leaves style undefined when not specified", () => {
+      ctx.font = "12px Arial";
+      expect(ctx._font.style).toBeUndefined();
+    });
+  });
+
+  describe("font variant", () => {
+    it("parses small-caps variant", () => {
+      ctx.font = "small-caps 12px Arial";
+      expect(ctx._font.variant).toBe("small-caps");
+      expect(ctx._font.size).toBe(12);
+      expect(ctx._font.family).toBe("Arial");
+    });
+
+    it("leaves variant undefined when not specified", () => {
+      ctx.font = "12px Arial";
+      expect(ctx._font.variant).toBeUndefined();
+    });
+  });
+
+  describe("combined properties", () => {
+    it("parses bold italic in order", () => {
+      ctx.font = "bold italic 14px Arial";
+      expect(ctx._font.weight).toBe(700);
+      expect(ctx._font.style).toBe("italic");
+      expect(ctx._font.size).toBe(14);
+      expect(ctx._font.family).toBe("Arial");
+    });
+
+    it("parses italic bold in reverse order", () => {
+      ctx.font = "italic bold 14px Arial";
+      expect(ctx._font.weight).toBe(700);
+      expect(ctx._font.style).toBe("italic");
+      expect(ctx._font.size).toBe(14);
+    });
+
+    it("parses italic small-caps bold together", () => {
+      ctx.font = "italic small-caps bold 16px Georgia";
+      expect(ctx._font.style).toBe("italic");
+      expect(ctx._font.variant).toBe("small-caps");
+      expect(ctx._font.weight).toBe(700);
+      expect(ctx._font.size).toBe(16);
+      expect(ctx._font.family).toBe("Georgia");
+    });
+
+    it("parses italic with numeric weight", () => {
+      ctx.font = "italic 600 18px 'Source Sans Pro'";
+      expect(ctx._font.style).toBe("italic");
+      expect(ctx._font.weight).toBe(600);
+      expect(ctx._font.size).toBe(18);
+      expect(ctx._font.family).toBe("Source Sans Pro");
+    });
+
+    it("parses bold with quoted family with spaces", () => {
+      ctx.font = "bold 48pt 'Source Sans Pro'";
+      expect(ctx._font.weight).toBe(700);
+      expect(ctx._font.size).toBe(48);
+      expect(ctx._font.family).toBe("Source Sans Pro");
+    });
+  });
+
+  describe("font getter round-trip", () => {
+    it("returns size with px unit and family", () => {
+      ctx.font = "12px Arial";
+      expect(ctx.font).toBe("12px Arial");
+    });
+
+    it("includes weight as number in output", () => {
+      ctx.font = "bold 12px Arial";
+      expect(ctx.font).toBe("700 12px Arial");
+    });
+
+    it("includes style in output", () => {
+      ctx.font = "italic 12px Arial";
+      expect(ctx.font).toBe("italic 12px Arial");
+    });
+
+    it("includes all parts in correct order", () => {
+      ctx.font = "italic bold 14px Georgia";
+      expect(ctx.font).toBe("italic 700 14px Georgia");
+    });
+
+    it("omits unset properties", () => {
+      ctx.font = "small-caps 16px Verdana";
+      expect(ctx.font).toBe("small-caps 16px Verdana");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("ignores the normal keyword", () => {
+      ctx.font = "normal 12px Arial";
+      expect(ctx._font.size).toBe(12);
+      expect(ctx._font.family).toBe("Arial");
+    });
+
+    it("does not crash on empty string, leaves font unchanged", () => {
+      ctx.font = "12px Arial";
+      ctx.font = "";
+      expect(ctx._font.size).toBe(12);
+      expect(ctx._font.family).toBe("Arial");
+    });
+
+    it("does not crash on size-only string, leaves font unchanged", () => {
+      ctx.font = "12px Arial";
+      ctx.font = "48px";
+      expect(ctx._font.family).toBe("Arial");
+    });
+
+    it("trims surrounding whitespace", () => {
+      ctx.font = "  16px Verdana  ";
+      expect(ctx._font.size).toBe(16);
+      expect(ctx._font.family).toBe("Verdana");
+    });
+
+    it("clears style and weight on subsequent plain assignment", () => {
+      ctx.font = "bold italic 14px Arial";
+      ctx.font = "12px Arial";
+      expect(ctx._font.weight).toBeUndefined();
+      expect(ctx._font.style).toBeUndefined();
+    });
+  });
+});
+
+describe("font rendering with weight and style metadata", () => {
+  it("renders text after setting bold font without crashing", async () => {
+    const fnt = pureimage.registerFont(
+      "test/unit/fixtures/fonts/SourceSansPro-Regular.ttf",
+      "Source Sans Pro",
+    );
+    await fnt.loadPromise();
+    const image = pureimage.make(200, 100);
+    const ctx = image.getContext("2d");
+    ctx.fillStyle = "white";
+    ctx.fillRect(0, 0, 200, 100);
+    ctx.fillStyle = "black";
+    ctx.font = "bold 48px 'Source Sans Pro'";
+    expect(ctx._font.weight).toBe(700);
+    expect(ctx._font.size).toBe(48);
+    expect(() => ctx.fillText("Hi", 10, 60)).not.toThrow();
+  });
+
+  it("measures text consistently after weight is set", async () => {
+    const fnt = pureimage.registerFont(
+      "test/unit/fixtures/fonts/SourceSansPro-Regular.ttf",
+      "Source Sans Pro",
+    );
+    await fnt.loadPromise();
+    const image = pureimage.make(200, 100);
+    const ctx = image.getContext("2d");
+
+    ctx.font = "48px 'Source Sans Pro'";
+    const plain = ctx.measureText("some text");
+
+    ctx.font = "bold 48px 'Source Sans Pro'";
+    const bold = ctx.measureText("some text");
+
+    // Same underlying font file — metrics should be equal
+    expect(bold.width).toBe(plain.width);
+  });
+});


### PR DESCRIPTION
The old parser split on the first space, causing any font string with style/weight keywords (e.g. "bold 12px Arial") to silently corrupt the font state (size = NaN, family = "12px Arial").

Replaced it with parseFontString() which iterates tokens and correctly recognises style (italic, oblique), variant (small-caps), weight keywords and numeric weights (100–900), then requires a unit-suffixed size token (px/pt/em/rem/etc.) before taking the remainder as the family name. Invalid strings now leave _font unchanged. The getter is updated to reconstruct a proper CSS font string from all stored properties.

Added test/font-parsing.test.ts with 39 tests covering all previously untested combinations.

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
 -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Description

<!--
Describe your changes here as well and any potential areas of interest you may wish to draw attention to
-->

<!--
PR Template copied(and modified) from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
